### PR TITLE
Add support to connection template

### DIFF
--- a/examples/oneview_connection_template.yml
+++ b/examples/oneview_connection_template.yml
@@ -1,0 +1,45 @@
+###
+# Copyright (2016) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+---
+- hosts: all
+  vars:
+    config: "{{ playbook_dir }}/oneview_config.json"
+  tasks:
+    - name: Update the Connection Template
+      oneview_connection_template:
+        config: "{{ config }}"
+        state: present
+        data:
+            name: 'name1304244267-1467656930023'
+            type : "connection-template"
+            bandwidth :
+                maximumBandwidth : 10000
+                typicalBandwidth : 2000
+            newName : "CT-23"
+      delegate_to: localhost
+
+    - name: Update back the Connection Template
+      oneview_connection_template:
+        config: "{{ config }}"
+        state: present
+        data:
+            name: "CT-23"
+            type : "connection-template"
+            bandwidth :
+                maximumBandwidth : 10000
+                typicalBandwidth : 2000
+            newName : 'name1304244267-1467656930023'
+      delegate_to: localhost

--- a/examples/oneview_connection_template_facts.yml
+++ b/examples/oneview_connection_template_facts.yml
@@ -1,0 +1,46 @@
+###
+# Copyright (2016) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+---
+- hosts: all
+  vars:
+    - config: "{{ playbook_dir }}/oneview_config.json"
+    - connection_template_name: 'name2139069875-1471287701836'
+  tasks:
+    - name: Gather facts about all Connection Templates
+      oneview_connection_template_facts:
+        config: "{{ config }}"
+      delegate_to: localhost
+
+    - debug: var=connection_templates
+
+
+    - name: Gather facts about a Connection Template by name
+      oneview_connection_template_facts:
+        config: "{{ config }}"
+        name: '{{ connection_template_name }}'
+      delegate_to: localhost
+
+    - debug: var=connection_templates
+
+
+    - name: Gather facts about the Default Connection Template
+      oneview_connection_template_facts:
+        config: "{{ config }}"
+        options:
+          - defaultConnectionTemplate
+      delegate_to: localhost
+
+    - debug: var=default_connection_template

--- a/examples/oneview_ethernet_network.yml
+++ b/examples/oneview_ethernet_network.yml
@@ -17,38 +17,42 @@
 - hosts: all
   vars:
     config: "{{ playbook_dir }}/oneview_config.json"
+    network_name: 'OneViewSDK Test Ethernet Network'
   tasks:
     - name: Create an Ethernet Network
       oneview_ethernet_network:
         config: "{{ config }}"
         state: present
         data:
-          name: "OneViewSDK Test Ethernet Network"
+          name: '{{ network_name }}'
           vlanId: 200
           ethernetNetworkType: Tagged
           purpose: General
           smartLink: false
           privateNetwork: false
-          connectionTemplateUri: null
+          bandwidth:
+              maximumBandwidth: 2000
+              typicalBandwidth: 1000
       delegate_to: localhost
 
-    - name: Do nothing with the Ethernet Network when no changes are provided
+    - name: Update the Ethernet Network changing bandwidth and purpose
       oneview_ethernet_network:
         config: "{{ config }}"
         state: present
         data:
-          name: "OneViewSDK Test Ethernet Network"
-          vlanId: 200
-          ethernetNetworkType: Tagged
-      delegate_to: localhost
-
-    - name: Update the Ethernet Network changing the attribute purpose to 'Management'
-      oneview_ethernet_network:
-        config: "{{ config }}"
-        state: present
-        data:
-          name: "OneViewSDK Test Ethernet Network"
+          name: '{{ network_name }}'
           purpose: Management
+          bandwidth:
+              maximumBandwidth: 3000
+              typicalBandwidth: 2000
+      delegate_to: localhost
+
+    - name: Reset to the default network connection template
+      oneview_ethernet_network:
+        config: "{{ config }}"
+        state: default_bandwidth_reset
+        data:
+          name: '{{ network_name }}'
       delegate_to: localhost
 
     - name: Rename the Ethernet Network to 'Updated Ethernet Network'
@@ -56,20 +60,11 @@
         config: "{{ config }}"
         state: present
         data:
-          name: "OneViewSDK Test Ethernet Network"
+          name: '{{ network_name }}'
           newName: 'Updated Ethernet Network'
       delegate_to: localhost
 
     - name: Delete the Ethernet Network
-      oneview_ethernet_network:
-        config: "{{ config }}"
-        state: absent
-        data:
-          name: 'Updated Ethernet Network'
-      delegate_to: localhost
-      register: deleted
-
-    - name: Do nothing when the Ethernet Network is absent
       oneview_ethernet_network:
         config: "{{ config }}"
         state: absent

--- a/library/oneview_connection_template.py
+++ b/library/oneview_connection_template.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+###
+# Copyright (2016) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+from ansible.module_utils.basic import *
+from hpOneView.oneview_client import OneViewClient
+from hpOneView.common import resource_compare
+
+DOCUMENTATION = '''
+---
+module: oneview_connection_template
+short_description: Manage OneView Connection Template resources.
+description:
+    - "Provides an interface to manage Connection Template resources. Can just update."
+requirements:
+    - "python >= 2.7.9"
+    - "hpOneView"
+author: "Gustavo Hennig (@GustavoHennig)"
+options:
+    config:
+        description:
+            - Path to a .json configuration file containing the OneView client configuration.
+        required: true
+    state:
+        description:
+            - Indicates the desired state for the Connection Template resource.
+              'present' will ensure data properties are compliant to OneView.
+        choices: ['present']
+        required: true
+    data:
+        description:
+            - List with Connection Template properties and its associated states
+        required: true
+notes:
+    - "A sample configuration file for the config parameter can be found at:
+       https://github.com/HewlettPackard/oneview-ansible/blob/master/examples/oneview_config-rename.json"
+'''
+
+EXAMPLES = '''
+- name: Update the Connection Template
+  oneview_connection_template:
+    config: "{{ config }}"
+    state: present
+    data:
+        name: 'name1304244267-1467656930023'
+        type : "connection-template"
+        bandwidth :
+            maximumBandwidth : 10000
+            typicalBandwidth : 2000
+        newName : "CT-23"
+  delegate_to: localhost
+'''
+
+RETURN = '''
+connection_template:
+    description: Has the OneView facts about the Connection Template.
+    returned: On 'present' state, but can be null.
+    type: complex
+'''
+
+CONNECTION_TEMPLATE_UPDATED = 'Connection Template updated successfully.'
+CONNECTION_TEMPLATE_NOT_FOUND = 'Connection Template was not found.'
+CONNECTION_TEMPLATE_ALREADY_UPDATED = 'Connection Template is already updated.'
+CONNECTION_TEMPLATE_MANDATORY_FIELD_MISSING = "Mandatory field was not informed: data.name"
+
+
+class ConnectionTemplateModule(object):
+    argument_spec = dict(
+        config=dict(required=True, type='str'),
+        state=dict(
+            required=True,
+            choices=['present']
+        ),
+        data=dict(required=True, type='dict')
+    )
+
+    def __init__(self):
+        self.module = AnsibleModule(argument_spec=self.argument_spec, supports_check_mode=False)
+        self.oneview_client = OneViewClient.from_json_file(self.module.params['config'])
+
+    def run(self):
+        try:
+            state = self.module.params['state']
+            data = self.module.params['data']
+            changed, msg, ansible_facts = False, '', {}
+
+            if not data.get('name'):
+                raise Exception(CONNECTION_TEMPLATE_MANDATORY_FIELD_MISSING)
+
+            resource = (self.oneview_client.connection_templates.get_by("name", data['name']) or [None])[0]
+
+            if state == 'present':
+                changed, msg, ansible_facts = self.__present(data, resource)
+
+            self.module.exit_json(changed=changed,
+                                  msg=msg,
+                                  ansible_facts=ansible_facts)
+
+        except Exception as exception:
+            self.module.fail_json(msg=exception.args[0])
+
+    def __present(self, data, resource):
+
+        changed = False
+        msg = ''
+
+        if not resource:
+            raise Exception(CONNECTION_TEMPLATE_NOT_FOUND)
+        else:
+            if 'newName' in data:
+                data['name'] = data.pop('newName')
+
+            merged_data = resource.copy()
+            merged_data.update(data)
+
+            if not resource_compare(resource, merged_data):
+                # update resource
+                changed = True
+                resource = self.oneview_client.connection_templates.update(merged_data)
+                msg = CONNECTION_TEMPLATE_UPDATED
+            else:
+                msg = CONNECTION_TEMPLATE_ALREADY_UPDATED
+
+        return changed, msg, dict(connection_template=resource)
+
+
+def main():
+    ConnectionTemplateModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/library/oneview_connection_template_facts.py
+++ b/library/oneview_connection_template_facts.py
@@ -73,7 +73,7 @@ EXAMPLES = '''
 RETURN = '''
 connection_templates:
     description: Has all the OneView facts about the Connection Templates.
-    returned: always, except whe defaultConnectionTemplate is requeste. Can be null.
+    returned: Always, except when defaultConnectionTemplate is requested. Can be null.
     type: complex
 
 default_connection_template:

--- a/library/oneview_connection_template_facts.py
+++ b/library/oneview_connection_template_facts.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python
+###
+# Copyright (2016) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+from ansible.module_utils.basic import *
+from hpOneView.oneview_client import OneViewClient
+
+DOCUMENTATION = '''
+---
+module: oneview_connection_template_facts
+short_description: Retrieve facts about Connection Templates of the OneView.
+description:
+    - Retrieve facts about Connection Templates of the OneView.
+requirements:
+    - "python >= 2.7.9"
+    - "hpOneView"
+author: "Gustavo Hennig (@GustavoHennig)"
+options:
+    config:
+      description:
+        - Path to a .json configuration file containing the OneView client configuration.
+      required: true
+    name:
+      description:
+        - Connection Template name.
+      required: false
+    options:
+      description:
+        - "List with options to gather additional facts about Connection Template related resources.
+           Options allowed: defaultConnectionTemplate"
+      required: false
+notes:
+    - "A sample configuration file for the config parameter can be found at:
+       https://github.com/HewlettPackard/oneview-ansible/blob/master/examples/oneview_config-rename.json"
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Connection Templates
+  oneview_connection_template_facts:
+    config: "{{ config }}"
+  delegate_to: localhost
+- debug: var=connection_templates
+
+- name: Gather facts about a Connection Template by name
+  oneview_connection_template_facts:
+    config: "{{ config }}"
+    name: 'connection template name'
+  delegate_to: localhost
+- debug: var=connection_templates
+
+- name: Gather facts about the Default Connection Template
+  oneview_connection_template_facts:
+    config: "{{ config }}"
+    options:
+      - defaultConnectionTemplate
+  delegate_to: localhost
+- debug: var=default_connection_template
+'''
+
+RETURN = '''
+connection_templates:
+    description: Has all the OneView facts about the Connection Templates.
+    returned: always, except whe defaultConnectionTemplate is requeste. Can be null.
+    type: complex
+
+default_connection_template:
+    description: Has the facts about the Default Connection Template.
+    returned: When requested, but can be null.
+    type: complex
+'''
+
+
+class ConnectionTemplateFactsModule(object):
+    argument_spec = {
+        "config": {
+            "required": True,
+            "type": 'str'
+        },
+        "name": {
+            "required": False,
+            "type": 'str'
+        },
+        "options": {
+            "required": False,
+            "type": 'list'
+        }}
+
+    def __init__(self):
+        self.module = AnsibleModule(argument_spec=self.argument_spec, supports_check_mode=False)
+        self.oneview_client = OneViewClient.from_json_file(self.module.params['config'])
+
+    def run(self):
+        try:
+            client = self.oneview_client.connection_templates
+
+            ansible_facts = {}
+
+            if self.module.params.get('options') and 'defaultConnectionTemplate' in self.module.params['options']:
+                ansible_facts['default_connection_template'] = client.get_default()
+            elif self.module.params.get('name'):
+                ansible_facts['connection_templates'] = client.get_by('name', self.module.params['name'])
+            else:
+                ansible_facts['connection_templates'] = client.get_all()
+
+            self.module.exit_json(changed=False,
+                                  ansible_facts=ansible_facts)
+
+        except Exception as exception:
+            self.module.fail_json(msg=exception.message)
+
+
+def main():
+    ConnectionTemplateFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/test_oneview_connection_template.py
+++ b/test/test_oneview_connection_template.py
@@ -1,0 +1,159 @@
+###
+# Copyright (2016) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+import unittest
+import mock
+import yaml
+
+from hpOneView.oneview_client import OneViewClient
+from oneview_connection_template import ConnectionTemplateModule, \
+    CONNECTION_TEMPLATE_MANDATORY_FIELD_MISSING, CONNECTION_TEMPLATE_NOT_FOUND, \
+    CONNECTION_TEMPLATE_ALREADY_UPDATED, CONNECTION_TEMPLATE_UPDATED
+
+FAKE_MSG_ERROR = 'Fake message error'
+
+YAML_CONNECTION_TEMPLATE = """
+        config: "{{ config }}"
+        state: present
+        data:
+            name: 'name1304244267-1467656930023'
+            type : "connection-template"
+            bandwidth :
+                maximumBandwidth : 10000
+                typicalBandwidth : 2000
+          """
+
+YAML_CONNECTION_TEMPLATE_CHANGE = """
+        config: "{{ config }}"
+        state: present
+        data:
+            name: 'name1304244267-1467656930023'
+            type : "connection-template"
+            bandwidth :
+                maximumBandwidth : 10000
+                typicalBandwidth : 2000
+            newName : "CT-23"
+      """
+
+YAML_CONNECTION_TEMPLATE_MISSING_KEY = """
+        config: "{{ config }}"
+        state: present
+        data:
+            state: "Configured"
+    """
+
+DICT_DEFAULT_CONNECTION_TEMPLATE = yaml.load(YAML_CONNECTION_TEMPLATE)["data"]
+DICT_DEFAULT_CONNECTION_TEMPLATE_CHANGED = yaml.load(YAML_CONNECTION_TEMPLATE_CHANGE)["data"]
+
+
+def create_ansible_mock(yaml_config):
+    mock_ansible = mock.Mock()
+    mock_ansible.params = yaml.load(yaml_config)
+    return mock_ansible
+
+
+class ConnectionTemplatePresentStateSpec(unittest.TestCase):
+    @mock.patch.object(OneViewClient, 'from_json_file')
+    @mock.patch('oneview_connection_template.AnsibleModule')
+    def test_should_update_the_connection_template(self, mock_ansible_module, mock_ov_client_from_json_file):
+        mock_ov_instance = mock.Mock()
+        mock_ov_instance.connection_templates.get_by.return_value = [DICT_DEFAULT_CONNECTION_TEMPLATE]
+        mock_ov_instance.connection_templates.update.return_value = {"name": "name"}
+
+        mock_ov_client_from_json_file.return_value = mock_ov_instance
+        mock_ansible_instance = create_ansible_mock(YAML_CONNECTION_TEMPLATE_CHANGE)
+        mock_ansible_module.return_value = mock_ansible_instance
+
+        ConnectionTemplateModule().run()
+
+        mock_ansible_instance.exit_json.assert_called_once_with(
+            changed=True,
+            msg=CONNECTION_TEMPLATE_UPDATED,
+            ansible_facts=dict(connection_template={"name": "name"})
+        )
+
+    @mock.patch.object(OneViewClient, 'from_json_file')
+    @mock.patch('oneview_connection_template.AnsibleModule')
+    def test_should_not_update_when_data_is_equals(self, mock_ansible_module, mock_ov_client_from_json_file):
+        mock_ov_instance = mock.Mock()
+        mock_ov_instance.connection_templates.get_by.return_value = [DICT_DEFAULT_CONNECTION_TEMPLATE]
+
+        mock_ov_client_from_json_file.return_value = mock_ov_instance
+        mock_ansible_instance = create_ansible_mock(YAML_CONNECTION_TEMPLATE)
+        mock_ansible_module.return_value = mock_ansible_instance
+
+        ConnectionTemplateModule().run()
+
+        mock_ansible_instance.exit_json.assert_called_once_with(
+            changed=False,
+            msg=CONNECTION_TEMPLATE_ALREADY_UPDATED,
+            ansible_facts=dict(connection_template=DICT_DEFAULT_CONNECTION_TEMPLATE)
+        )
+
+
+class ConnectionTemplateErrorHandlingSpec(unittest.TestCase):
+    @mock.patch.object(OneViewClient, 'from_json_file')
+    @mock.patch('oneview_connection_template.AnsibleModule')
+    def test_should_fail_when_update_raises_exception(self, mock_ansible_module, mock_ov_client_from_json_file):
+        mock_ov_instance = mock.Mock()
+        mock_ov_instance.connection_templates.get_by.return_value = [DICT_DEFAULT_CONNECTION_TEMPLATE]
+        mock_ov_instance.connection_templates.update.side_effect = Exception(FAKE_MSG_ERROR)
+
+        mock_ov_client_from_json_file.return_value = mock_ov_instance
+        mock_ansible_instance = create_ansible_mock(YAML_CONNECTION_TEMPLATE_CHANGE)
+        mock_ansible_module.return_value = mock_ansible_instance
+
+        self.assertRaises(Exception, ConnectionTemplateModule().run())
+
+        mock_ansible_instance.fail_json.assert_called_once_with(
+            msg=FAKE_MSG_ERROR
+        )
+
+    @mock.patch.object(OneViewClient, 'from_json_file')
+    @mock.patch('oneview_connection_template.AnsibleModule')
+    def test_should_raise_exception_when_key_is_missing(self, mock_ansible_module, mock_ov_client_from_json_file):
+        mock_ov_instance = mock.Mock()
+        mock_ov_instance.connection_templates.get_by.return_value = [DICT_DEFAULT_CONNECTION_TEMPLATE]
+
+        mock_ov_client_from_json_file.return_value = mock_ov_instance
+        mock_ansible_instance = create_ansible_mock(YAML_CONNECTION_TEMPLATE_MISSING_KEY)
+        mock_ansible_module.return_value = mock_ansible_instance
+
+        self.assertRaises(Exception, ConnectionTemplateModule().run())
+
+        mock_ansible_instance.fail_json.assert_called_once_with(
+            msg=CONNECTION_TEMPLATE_MANDATORY_FIELD_MISSING
+        )
+
+    @mock.patch.object(OneViewClient, 'from_json_file')
+    @mock.patch('oneview_connection_template.AnsibleModule')
+    def test_should_raise_exception_when_connection_template_was_not_found(self, mock_ansible_module,
+                                                                           mock_ov_client_from_json_file):
+        mock_ov_instance = mock.Mock()
+        mock_ov_instance.connection_templates.get_by.return_value = []
+
+        mock_ov_client_from_json_file.return_value = mock_ov_instance
+        mock_ansible_instance = create_ansible_mock(YAML_CONNECTION_TEMPLATE)
+        mock_ansible_module.return_value = mock_ansible_instance
+
+        ConnectionTemplateModule().run()
+
+        mock_ansible_instance.fail_json.assert_called_once_with(
+            msg=CONNECTION_TEMPLATE_NOT_FOUND
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_oneview_connection_template_facts.py
+++ b/test/test_oneview_connection_template_facts.py
@@ -1,0 +1,158 @@
+###
+# Copyright (2016) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+import unittest
+import mock
+
+from hpOneView.oneview_client import OneViewClient
+from oneview_connection_template_facts import ConnectionTemplateFactsModule
+
+ERROR_MSG = 'Fake message error'
+
+PARAMS_MANDATORY_MISSING = dict(
+    config='config.json',
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name="name1304244267-1467656930023"
+)
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+)
+
+PARAMS_GET_DEFAULT = dict(
+    config='config.json',
+    options=['defaultConnectionTemplate']
+)
+
+
+def create_ansible_mock(dict_params):
+    mock_ansible = mock.Mock()
+    mock_ansible.params = dict_params
+    return mock_ansible
+
+
+class ConnectionTemplatesFactsSpec(unittest.TestCase):
+    @mock.patch.object(OneViewClient, 'from_json_file')
+    @mock.patch('oneview_connection_template_facts.AnsibleModule')
+    def test_should_get_all_connection_templates(self, mock_ansible_module,
+                                                 mock_ov_client_from_json_file):
+        mock_ov_instance = mock.Mock()
+        mock_ov_instance.connection_templates.get_all.return_value = {"name": "Storage System Name"}
+
+        mock_ov_client_from_json_file.return_value = mock_ov_instance
+
+        mock_ansible_instance = create_ansible_mock(PARAMS_GET_ALL)
+        mock_ansible_module.return_value = mock_ansible_instance
+
+        ConnectionTemplateFactsModule().run()
+
+        mock_ansible_instance.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(connection_templates=({"name": "Storage System Name"}))
+        )
+
+    @mock.patch.object(OneViewClient, 'from_json_file')
+    @mock.patch('oneview_connection_template_facts.AnsibleModule')
+    def test_should_fail_when_get_all_raises_exception(self, mock_ansible_module, mock_ov_client_from_json_file):
+        mock_ov_instance = mock.Mock()
+        mock_ov_instance.connection_templates.get_all.side_effect = Exception(ERROR_MSG)
+
+        mock_ov_client_from_json_file.return_value = mock_ov_instance
+
+        mock_ansible_instance = create_ansible_mock(PARAMS_GET_ALL)
+        mock_ansible_module.return_value = mock_ansible_instance
+
+        ConnectionTemplateFactsModule().run()
+
+        mock_ansible_instance.fail_json.assert_called_once()
+
+    @mock.patch.object(OneViewClient, 'from_json_file')
+    @mock.patch('oneview_connection_template_facts.AnsibleModule')
+    def test_should_get_connection_template_by_name(self, mock_ansible_module,
+                                                    mock_ov_client_from_json_file):
+        mock_ov_instance = mock.Mock()
+        mock_ov_instance.connection_templates.get_by.return_value = {"name": "Storage System Name"}
+
+        mock_ov_client_from_json_file.return_value = mock_ov_instance
+
+        mock_ansible_instance = create_ansible_mock(PARAMS_GET_BY_NAME)
+        mock_ansible_module.return_value = mock_ansible_instance
+
+        ConnectionTemplateFactsModule().run()
+
+        mock_ansible_instance.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(connection_templates=({"name": "Storage System Name"}))
+        )
+
+    @mock.patch.object(OneViewClient, 'from_json_file')
+    @mock.patch('oneview_connection_template_facts.AnsibleModule')
+    def test_should_fail_when_get_by_raises_exception(self, mock_ansible_module, mock_ov_client_from_json_file):
+        mock_ov_instance = mock.Mock()
+        mock_ov_instance.connection_templates.get_by.side_effect = Exception(ERROR_MSG)
+
+        mock_ov_client_from_json_file.return_value = mock_ov_instance
+
+        mock_ansible_instance = create_ansible_mock(PARAMS_GET_BY_NAME)
+        mock_ansible_module.return_value = mock_ansible_instance
+
+        ConnectionTemplateFactsModule().run()
+
+        mock_ansible_instance.fail_json.assert_called_once()
+
+    @mock.patch.object(OneViewClient, 'from_json_file')
+    @mock.patch('oneview_connection_template_facts.AnsibleModule')
+    def test_should_get_default_connection_template(self, mock_ansible_module,
+                                                    mock_ov_client_from_json_file):
+        mock_ov_instance = mock.Mock()
+        mock_ov_instance.connection_templates.get_default.return_value = {
+            "name": "default_connection_template"}
+
+        mock_ov_client_from_json_file.return_value = mock_ov_instance
+
+        mock_ansible_instance = create_ansible_mock(PARAMS_GET_DEFAULT)
+        mock_ansible_module.return_value = mock_ansible_instance
+
+        ConnectionTemplateFactsModule().run()
+
+        mock_ansible_instance.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts={'default_connection_template': {'name': 'default_connection_template'}}
+        )
+
+    @mock.patch.object(OneViewClient, 'from_json_file')
+    @mock.patch('oneview_connection_template_facts.AnsibleModule')
+    def test_should_fail_when_get_default_raises_exception(self,
+                                                           mock_ansible_module,
+                                                           mock_ov_client_from_json_file):
+        mock_ov_instance = mock.Mock()
+        mock_ov_instance.connection_templates.get_default.side_effect = Exception(ERROR_MSG)
+
+        mock_ov_client_from_json_file.return_value = mock_ov_instance
+
+        mock_ansible_instance = create_ansible_mock(PARAMS_GET_DEFAULT)
+        mock_ansible_module.return_value = mock_ansible_instance
+
+        ConnectionTemplateFactsModule().run()
+
+        mock_ansible_instance.fail_json.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Implemented Connection Template Module and Facts

In Ethernet Network module:
- Implemented transparent connection template update when Ethernet Network is changed (create or update);
- Implemented new state to reset connection template to the default.