### PR TITLE
Change type of option 'param' on facts modules from list to dict

### DIFF
--- a/examples/oneview_connection_template_facts.yml
+++ b/examples/oneview_connection_template_facts.yml
@@ -30,10 +30,10 @@
       oneview_connection_template_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
-          - filter: 'name=defaultConnectionTemplate'
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: 'name=defaultConnectionTemplate'
 
     - debug: var=connection_templates
 

--- a/examples/oneview_datacenter_facts.yml
+++ b/examples/oneview_datacenter_facts.yml
@@ -30,10 +30,10 @@
       oneview_datacenter_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
-          - filter: 'state=Unmanaged'
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: 'state=Unmanaged'
 
     - debug: var=datacenters
 

--- a/examples/oneview_drive_enclosure_facts.yml
+++ b/examples/oneview_drive_enclosure_facts.yml
@@ -31,10 +31,10 @@
       oneview_drive_enclosure_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
-          - filter: 'status=Warning'
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: 'status=Warning'
 
     - debug: var=drive_enclosures
 

--- a/examples/oneview_enclosure_facts.yml
+++ b/examples/oneview_enclosure_facts.yml
@@ -30,10 +30,10 @@
       oneview_enclosure_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
-          - filter: 'status=OK'
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: 'status=OK'
 
     - debug: var=enclosures
 

--- a/examples/oneview_enclosure_group_facts.yml
+++ b/examples/oneview_enclosure_group_facts.yml
@@ -30,10 +30,10 @@
       oneview_enclosure_group_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
-          - filter: 'status=OK'
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: 'status=OK'
 
     - debug: var=enclosure_groups
 

--- a/examples/oneview_ethernet_network_facts.yml
+++ b/examples/oneview_ethernet_network_facts.yml
@@ -30,10 +30,10 @@
       oneview_ethernet_network_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
-          - filter: "purpose=General"
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: "purpose=General"
 
     - debug: var=ethernet_networks
 

--- a/examples/oneview_fabric_facts.yml
+++ b/examples/oneview_fabric_facts.yml
@@ -30,10 +30,10 @@
       oneview_fabric_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
-          - filter: 'name=DefaultFabric'
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: 'name=DefaultFabric'
 
     - debug: var=fabrics
 

--- a/examples/oneview_fc_network_facts.yml
+++ b/examples/oneview_fc_network_facts.yml
@@ -29,10 +29,10 @@
       oneview_fc_network_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
-          - filter: 'fabricType=FabricAttach'
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: 'fabricType=FabricAttach'
     - debug: var=fc_networks
 
     - name: Gather facts about a Fibre Channel Network by name

--- a/examples/oneview_fcoe_network_facts.yml
+++ b/examples/oneview_fcoe_network_facts.yml
@@ -29,10 +29,10 @@
       oneview_fcoe_network_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
-          - filter: 'vlanId=2'
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: 'vlanId=2'
 
     - debug: var=fcoe_networks
 

--- a/examples/oneview_firmware_driver_facts.yml
+++ b/examples/oneview_firmware_driver_facts.yml
@@ -28,9 +28,9 @@
       oneview_firmware_driver_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
+          start: 0
+          count: 3
+          sort: 'name:descending'
 
     - debug: var=firmware_drivers
 

--- a/examples/oneview_interconnect_facts.yml
+++ b/examples/oneview_interconnect_facts.yml
@@ -36,10 +36,10 @@
       oneview_interconnect_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 5
-          - sort: 'name:descending'
-          - filter: "enclosureName='0000A66101'"
+          start: 0
+          count: 5
+          sort: 'name:descending'
+          filter: "enclosureName='0000A66101'"
 
     - debug: var=interconnects
 

--- a/examples/oneview_interconnect_link_topology_facts.yml
+++ b/examples/oneview_interconnect_link_topology_facts.yml
@@ -27,6 +27,17 @@
 
     - debug: var=interconnect_link_topologies
 
+    - name: Gather paginated, filtered and sorted facts about Interconnect Link Topologies
+      oneview_interconnect_link_topology_facts:
+        config: "{{ config }}"
+        params:
+          - start: 0
+          - count: 3
+          - sort: 'name:descending'
+          - filter: "name='name1900571853-1483553596802'"
+
+    - debug: var=interconnect_link_topologies
+
     - name: Gather facts about an Interconnect Link Topology by name
       oneview_interconnect_link_topology_facts:
         config: "{{ config }}"

--- a/examples/oneview_interconnect_link_topology_facts.yml
+++ b/examples/oneview_interconnect_link_topology_facts.yml
@@ -31,10 +31,10 @@
       oneview_interconnect_link_topology_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
-          - filter: "name='name1900571853-1483553596802'"
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: "name='name1900571853-1483553596802'"
 
     - debug: var=interconnect_link_topologies
 

--- a/examples/oneview_interconnect_type_facts.yml
+++ b/examples/oneview_interconnect_type_facts.yml
@@ -28,10 +28,10 @@
       oneview_interconnect_type_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:descending'
-          - filter: "maximumFirmwareVersion='4000.99'"
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: "maximumFirmwareVersion='4000.99'"
     - debug:  msg="{{interconnect_types | map(attribute='name') | list }}"
 
     - name: Gather facts about an Interconnect Type by name {{ interconnect_types.0.name }}

--- a/examples/oneview_interconnect_type_facts.yml
+++ b/examples/oneview_interconnect_type_facts.yml
@@ -24,6 +24,16 @@
       delegate_to: localhost
     - debug: msg="{{interconnect_types | map(attribute='name') | list }}"
 
+    - name: Gather paginated, filtered and sorted facts about Interconnect Types
+      oneview_interconnect_type_facts:
+        config: "{{ config }}"
+        params:
+          - start: 0
+          - count: 3
+          - sort: 'name:descending'
+          - filter: "maximumFirmwareVersion='4000.99'"
+    - debug:  msg="{{interconnect_types | map(attribute='name') | list }}"
+
     - name: Gather facts about an Interconnect Type by name {{ interconnect_types.0.name }}
       oneview_interconnect_type_facts:
         config: "{{ config }}"

--- a/examples/oneview_internal_link_set_facts.yml
+++ b/examples/oneview_internal_link_set_facts.yml
@@ -28,6 +28,15 @@
 
     - debug: var=internal_link_sets
 
+    - name: Gather paginated and sorted facts about Internal Link Sets
+      oneview_internal_link_set_facts:
+        config: "{{ config }}"
+        params:
+          - start: 0
+          - count: 3
+          - sort: 'name:ascending'
+
+    - debug: var=internal_link_sets
 
     - name: Gather facts about an Internal Link Set by name
       oneview_internal_link_set_facts:

--- a/examples/oneview_internal_link_set_facts.yml
+++ b/examples/oneview_internal_link_set_facts.yml
@@ -32,9 +32,9 @@
       oneview_internal_link_set_facts:
         config: "{{ config }}"
         params:
-          - start: 0
-          - count: 3
-          - sort: 'name:ascending'
+          start: 0
+          count: 3
+          sort: 'name:ascending'
 
     - debug: var=internal_link_sets
 

--- a/examples/oneview_logical_downlinks_facts.yml
+++ b/examples/oneview_logical_downlinks_facts.yml
@@ -26,6 +26,17 @@
 
     - debug: var=logical_downlinks
 
+    - name: Gather paginated, filtered and sorted facts about Logical Downlinks
+      oneview_logical_downlinks_facts:
+        config: "{{ config }}"
+        params:
+          start: 0
+          count: 3
+          sort: 'name:descending'
+          filter: "name='LDa4c64fd9-0b76-46c3-8335-0bbb76459aff (Cisco Fabric Extender for HP BladeSystem)'"
+
+    - debug: var=logical_downlinks
+
     - name: Gather facts about all Logical Downlinks excluding any existing Ethernet networks
       oneview_logical_downlinks_facts:
         config: "{{ config }}"

--- a/library/oneview_connection_template_facts.py
+++ b/library/oneview_connection_template_facts.py
@@ -19,7 +19,6 @@ from ansible.module_utils.basic import *
 
 try:
     from hpOneView.oneview_client import OneViewClient
-    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
@@ -78,10 +77,10 @@ EXAMPLES = '''
   oneview_connection_template_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'name=defaultConnectionTemplate'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'name=defaultConnectionTemplate'
 
 - debug: var=connection_templates
 
@@ -131,7 +130,7 @@ class ConnectionTemplateFactsModule(object):
         },
         "params": {
             "required": False,
-            "type": 'list'
+            "type": 'dict'
         }
     }
 
@@ -156,9 +155,8 @@ class ConnectionTemplateFactsModule(object):
             elif self.module.params.get('name'):
                 ansible_facts['connection_templates'] = client.get_by('name', self.module.params['name'])
             else:
-                params = self.module.params.get('params')
-                get_all_params = transform_list_to_dict(params) if params else {}
-                ansible_facts['connection_templates'] = client.get_all(**get_all_params)
+                params = self.module.params.get('params') or {}
+                ansible_facts['connection_templates'] = client.get_all(**params)
 
             self.module.exit_json(changed=False,
                                   ansible_facts=ansible_facts)

--- a/library/oneview_datacenter_facts.py
+++ b/library/oneview_datacenter_facts.py
@@ -19,7 +19,6 @@ from ansible.module_utils.basic import *
 
 try:
     from hpOneView.oneview_client import OneViewClient
-    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
@@ -78,10 +77,10 @@ EXAMPLES = '''
   oneview_datacenter_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'state=Unmanaged'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'state=Unmanaged'
 
 - debug: var=datacenters
 
@@ -136,7 +135,7 @@ class DatacenterFactsModule(object):
         },
         "params": {
             "required": False,
-            "type": 'list'
+            "type": 'dict'
         },
     }
 
@@ -166,9 +165,8 @@ class DatacenterFactsModule(object):
 
                 ansible_facts['datacenters'] = datacenters
             else:
-                params = self.module.params.get('params')
-                get_all_params = transform_list_to_dict(params) if params else {}
-                ansible_facts['datacenters'] = client.get_all(**get_all_params)
+                params = self.module.params.get('params') or {}
+                ansible_facts['datacenters'] = client.get_all(**params)
 
             self.module.exit_json(changed=False,
                                   ansible_facts=ansible_facts)

--- a/library/oneview_drive_enclosure_facts.py
+++ b/library/oneview_drive_enclosure_facts.py
@@ -43,6 +43,15 @@ options:
           The configuration file is optional. If the file path is not provided, the configuration will be loaded from
           environment variables.
       required: false
+    params:
+      description:
+        - List of params to delimit, filter and sort the list of resources.
+        - "params allowed:
+          'start': The first item to return, using 0-based indexing.
+          'count': The number of resources to return.
+          'filter': A general filter/query string to narrow the list of items returned.
+          'sort': The sort order of the returned data set."
+      required: false
     name:
       description:
         - Drive Enclosure name.
@@ -70,10 +79,10 @@ EXAMPLES = '''
   oneview_drive_enclosure_facts:
     config: "{{ config_file_path }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'status=Warning'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'status=Warning'
 
 - debug: var=drive_enclosures
 
@@ -114,7 +123,7 @@ class DriveEnclosureFactsModule(object):
         config=dict(required=False, type='str'),
         name=dict(required=False, type='str'),
         options=dict(required=False, type='list'),
-        params=dict(required=False, type='list')
+        params=dict(required=False, type='dict')
     )
 
     def __init__(self):
@@ -143,9 +152,9 @@ class DriveEnclosureFactsModule(object):
                             facts['drive_enclosure_port_map'] = \
                                 self.oneview_client.drive_enclosures.get_port_map(drive_enclosures_uri)
             else:
-                params = self.module.params.get('params')
-                get_all_params = transform_list_to_dict(params) if params else {}
-                drive_enclosures = self.oneview_client.drive_enclosures.get_all(**get_all_params)
+                params = self.module.params.get('params') or {}
+
+                drive_enclosures = self.oneview_client.drive_enclosures.get_all(**params)
 
             facts['drive_enclosures'] = drive_enclosures
 

--- a/library/oneview_enclosure_facts.py
+++ b/library/oneview_enclosure_facts.py
@@ -80,10 +80,10 @@ EXAMPLES = '''
   oneview_enclosure_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'status=OK'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'status=OK'
 
 - debug: var=enclosures
 
@@ -159,7 +159,7 @@ class EnclosureFactsModule(object):
         config=dict(required=False, type='str'),
         name=dict(required=False, type='str'),
         options=dict(required=False, type='list'),
-        params=dict(required=False, type='list'),
+        params=dict(required=False, type='dict'),
     )
 
     def __init__(self):
@@ -229,9 +229,9 @@ class EnclosureFactsModule(object):
         return self.oneview_client.enclosures.get_by('name', name)
 
     def __get_all(self):
-        params = self.module.params.get('params')
-        get_all_params = transform_list_to_dict(params) if params else {}
-        return self.oneview_client.enclosures.get_all(**get_all_params)
+        params = self.module.params.get('params') or {}
+
+        return self.oneview_client.enclosures.get_all(**params)
 
 
 def main():

--- a/library/oneview_enclosure_group_facts.py
+++ b/library/oneview_enclosure_group_facts.py
@@ -20,7 +20,6 @@ from ansible.module_utils.basic import *
 
 try:
     from hpOneView.oneview_client import OneViewClient
-    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
@@ -83,10 +82,10 @@ EXAMPLES = '''
   oneview_enclosure_group_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'status=OK'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'status=OK'
 
 - debug: var=enclosure_groups
 
@@ -130,7 +129,7 @@ class EnclosureGroupFactsModule(object):
         },
         "params": {
             "required": False,
-            "type": "list"
+            "type": "dict"
         }}
 
     def __init__(self):
@@ -155,10 +154,9 @@ class EnclosureGroupFactsModule(object):
                 if enclosure_groups and "configuration_script" in options:
                     facts["enclosure_group_script"] = self.__get_script(enclosure_groups)
             else:
-                params = self.module.params.get('params')
-                get_all_params = transform_list_to_dict(params) if params else {}
+                params = self.module.params.get('params') or {}
 
-                enclosure_groups = self.oneview_client.enclosure_groups.get_all(**get_all_params)
+                enclosure_groups = self.oneview_client.enclosure_groups.get_all(**params)
 
             facts["enclosure_groups"] = enclosure_groups
             self.module.exit_json(changed=False, ansible_facts=facts)

--- a/library/oneview_ethernet_network_facts.py
+++ b/library/oneview_ethernet_network_facts.py
@@ -81,10 +81,10 @@ EXAMPLES = '''
   oneview_ethernet_network_facts:
     config: "{{ config_file_path }}"
     params:
-      - start: 1
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'purpose=General'
+      start: 1
+      count: 3
+      sort: 'name:descending'
+      filter: 'purpose=General'
 
 - debug: var=ethernet_networks
 
@@ -132,7 +132,7 @@ class EthernetNetworkFactsModule(object):
         config=dict(required=False, type='str'),
         name=dict(required=False, type='str'),
         options=dict(required=False, type='list'),
-        params=dict(required=False, type='list')
+        params=dict(required=False, type='dict')
     )
 
     def __init__(self):
@@ -194,10 +194,8 @@ class EthernetNetworkFactsModule(object):
         return self.oneview_client.ethernet_networks.get_by('name', name)
 
     def __get_all(self):
-        get_all_params = {}
-        if self.module.params.get('params'):
-            get_all_params = transform_list_to_dict(self.module.params['params'])
-        return self.oneview_client.ethernet_networks.get_all(**get_all_params)
+        params = self.module.params.get('params') or {}
+        return self.oneview_client.ethernet_networks.get_all(**params)
 
 
 def main():

--- a/library/oneview_fabric_facts.py
+++ b/library/oneview_fabric_facts.py
@@ -17,6 +17,7 @@
 ###
 
 from ansible.module_utils.basic import *
+
 try:
     from hpOneView.oneview_client import OneViewClient
     from hpOneView.common import transform_list_to_dict
@@ -78,10 +79,10 @@ EXAMPLES = '''
   oneview_fabric_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'name=DefaultFabric'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'name=DefaultFabric'
 
 - debug: var=fabrics
 
@@ -120,7 +121,7 @@ class FabricFactsModule(object):
         config=dict(required=False, type='str'),
         name=dict(required=False, type='str'),
         options=dict(required=False, type='list'),
-        params=dict(required=False, type='list')
+        params=dict(required=False, type='dict')
     )
 
     def __init__(self):
@@ -144,10 +145,9 @@ class FabricFactsModule(object):
                 if self.module.params.get('options') and fabrics:
                     ansible_facts = self.__gather_optional_facts(self.module.params['options'], fabrics[0])
             else:
-                params = self.module.params.get('params')
-                get_all_params = transform_list_to_dict(params) if params else {}
+                params = self.module.params.get('params') or {}
 
-                fabrics = self.oneview_client.fabrics.get_all(**get_all_params)
+                fabrics = self.oneview_client.fabrics.get_all(**params)
 
             ansible_facts['fabrics'] = fabrics
 

--- a/library/oneview_fc_network_facts.py
+++ b/library/oneview_fc_network_facts.py
@@ -20,7 +20,6 @@ from ansible.module_utils.basic import *
 
 try:
     from hpOneView.oneview_client import OneViewClient
-    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
@@ -75,10 +74,10 @@ EXAMPLES = '''
   oneview_fc_network_facts:
     config: "{{ config }}"
     params:
-      - start: 1
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'fabricType=FabricAttach'
+      start: 1
+      count: 3
+      sort: 'name:descending'
+      filter: 'fabricType=FabricAttach'
 - debug: var=fc_networks
 
 - name: Gather facts about a Fibre Channel Network by name
@@ -102,7 +101,7 @@ class FcNetworkFactsModule(object):
     argument_spec = dict(
         config=dict(required=False, type='str'),
         name=dict(required=False, type='str'),
-        params=dict(required=False, type='list')
+        params=dict(required=False, type='dict')
     )
 
     def __init__(self):
@@ -133,10 +132,8 @@ class FcNetworkFactsModule(object):
                               ansible_facts=dict(fc_networks=fc_network))
 
     def __get_all(self):
-        params = self.module.params.get('params')
-        get_all_params = transform_list_to_dict(params) if params else {}
-
-        fc_networks = self.oneview_client.fc_networks.get_all(**get_all_params)
+        params = self.module.params.get('params') or {}
+        fc_networks = self.oneview_client.fc_networks.get_all(**params)
 
         self.module.exit_json(changed=False,
                               ansible_facts=dict(fc_networks=fc_networks))

--- a/library/oneview_fcoe_network_facts.py
+++ b/library/oneview_fcoe_network_facts.py
@@ -17,14 +17,13 @@
 ###
 
 from ansible.module_utils.basic import *
+
 try:
     from hpOneView.oneview_client import OneViewClient
-    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
     HAS_HPE_ONEVIEW = False
-
 
 DOCUMENTATION = '''
 ---
@@ -74,10 +73,10 @@ EXAMPLES = '''
   oneview_fcoe_network_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'vlanId=2'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'vlanId=2'
 
 - debug: var=fcoe_networks
 
@@ -99,11 +98,10 @@ HPE_ONEVIEW_SDK_REQUIRED = 'HPE OneView Python SDK is required for this module.'
 
 
 class FcoeNetworkFactsModule(object):
-
     argument_spec = dict(
         config=dict(required=False, type='str'),
         name=dict(required=False, type='str'),
-        params=dict(required=False, type='list')
+        params=dict(required=False, type='dict')
     )
 
     def __init__(self):
@@ -134,10 +132,9 @@ class FcoeNetworkFactsModule(object):
                               ansible_facts=dict(fcoe_networks=fcoe_network))
 
     def __get_all(self):
-        params = self.module.params.get('params')
-        get_all_params = transform_list_to_dict(params) if params else {}
+        params = self.module.params.get('params') or {}
 
-        fcoe_network = self.oneview_client.fcoe_networks.get_all(**get_all_params)
+        fcoe_network = self.oneview_client.fcoe_networks.get_all(**params)
 
         self.module.exit_json(changed=False,
                               ansible_facts=dict(fcoe_networks=fcoe_network))

--- a/library/oneview_firmware_driver_facts.py
+++ b/library/oneview_firmware_driver_facts.py
@@ -20,7 +20,6 @@ from ansible.module_utils.basic import *
 
 try:
     from hpOneView.oneview_client import OneViewClient
-    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
@@ -73,9 +72,9 @@ EXAMPLES = '''
   oneview_firmware_driver_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
+      start: 0
+      count: 3
+      sort: 'name:descending'
 
 - debug: var=firmware_drivers
 
@@ -100,7 +99,7 @@ class FirmwareDriverFactsModule(object):
     argument_spec = dict(
         config=dict(required=False, type='str'),
         name=dict(required=False, type='str'),
-        params=dict(required=False, type='list')
+        params=dict(required=False, type='dict')
 
     )
 
@@ -126,9 +125,9 @@ class FirmwareDriverFactsModule(object):
             if name:
                 result = self.resource_client.get_by('name', name)
             else:
-                params = self.module.params.get('params')
-                get_all_params = transform_list_to_dict(params) if params else {}
-                result = self.resource_client.get_all(**get_all_params)
+                params = self.module.params.get('params') or {}
+
+                result = self.resource_client.get_all(**params)
 
             self.module.exit_json(
                 changed=False,

--- a/library/oneview_interconnect_facts.py
+++ b/library/oneview_interconnect_facts.py
@@ -84,10 +84,10 @@ EXAMPLES = '''
   oneview_interconnect_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 5
-      - sort: 'name:descending'
-      - filter: "enclosureName='0000A66101'"
+      start: 0
+      count: 5
+      sort: 'name:descending'
+      filter: "enclosureName='0000A66101'"
 
 - debug: var=interconnects
 
@@ -176,7 +176,7 @@ class InterconnectFactsModule(object):
         config=dict(required=False, type='str'),
         name=dict(required=False, type='str'),
         options=dict(required=False, type='list'),
-        params=dict(required=False, type='list'),
+        params=dict(required=False, type='dict'),
     )
 
     def __init__(self):
@@ -202,9 +202,9 @@ class InterconnectFactsModule(object):
                     self.__get_options(interconnects, facts)
 
             else:
-                params = self.module.params.get('params')
-                get_all_params = transform_list_to_dict(params) if params else {}
-                facts['interconnects'] = self.oneview_client.interconnects.get_all(**get_all_params)
+                params = self.module.params.get('params') or {}
+
+                facts['interconnects'] = self.oneview_client.interconnects.get_all(**params)
 
             self.module.exit_json(
                 changed=False,

--- a/library/oneview_interconnect_link_topology_facts.py
+++ b/library/oneview_interconnect_link_topology_facts.py
@@ -17,9 +17,9 @@
 ###
 
 from ansible.module_utils.basic import *
+
 try:
     from hpOneView.oneview_client import OneViewClient
-    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
@@ -74,10 +74,10 @@ EXAMPLES = '''
   oneview_interconnect_link_topology_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: "name='name1900571853-1483553596802'"
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: "name='name1900571853-1483553596802'"
 
 - debug: var=interconnect_link_topologies
 
@@ -102,7 +102,7 @@ class InterconnectLinkTopologyFactsModule(object):
     argument_spec = dict(
         config=dict(required=False, type='str'),
         name=dict(required=False, type='str'),
-        params=dict(required=False, type='list'),
+        params=dict(required=False, type='dict'),
     )
 
     def __init__(self):
@@ -121,8 +121,7 @@ class InterconnectLinkTopologyFactsModule(object):
                 name = self.module.params.get('name')
                 interconnect_link_topologies = self.oneview_client.interconnect_link_topologies.get_by('name', name)
             else:
-                params_list = self.module.params.get('params')
-                params = transform_list_to_dict(params_list) if params_list else {}
+                params = self.module.params.get('params') or {}
                 interconnect_link_topologies = self.oneview_client.interconnect_link_topologies.get_all(**params)
 
             self.module.exit_json(changed=False,

--- a/library/oneview_interconnect_link_topology_facts.py
+++ b/library/oneview_interconnect_link_topology_facts.py
@@ -19,6 +19,7 @@
 from ansible.module_utils.basic import *
 try:
     from hpOneView.oneview_client import OneViewClient
+    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
@@ -41,6 +42,15 @@ options:
           The configuration file is optional. If the file path is not provided, the configuration will be loaded from
           environment variables.
       required: false
+    params:
+      description:
+        - List of params to delimit, filter and sort the list of resources.
+        - "params allowed:
+          'start': The first item to return, using 0-based indexing.
+          'count': The number of resources to return.
+          'filter': A general filter/query string to narrow the list of items returned.
+          'sort': The sort order of the returned data set."
+      required: false
     name:
       description:
         - Name of the Interconnect Link Topology.
@@ -60,6 +70,16 @@ EXAMPLES = '''
 
 - debug: var=interconnect_link_topologies
 
+- name: Gather paginated, filtered and sorted facts about Interconnect Link Topologies
+  oneview_interconnect_link_topology_facts:
+    config: "{{ config }}"
+    params:
+      - start: 0
+      - count: 3
+      - sort: 'name:descending'
+      - filter: "name='name1900571853-1483553596802'"
+
+- debug: var=interconnect_link_topologies
 
 - name: Gather facts about an Interconnect Link Topology by name
   oneview_interconnect_link_topology_facts:
@@ -81,7 +101,8 @@ HPE_ONEVIEW_SDK_REQUIRED = 'HPE OneView Python SDK is required for this module.'
 class InterconnectLinkTopologyFactsModule(object):
     argument_spec = dict(
         config=dict(required=False, type='str'),
-        name=dict(required=False, type='str')
+        name=dict(required=False, type='str'),
+        params=dict(required=False, type='list'),
     )
 
     def __init__(self):
@@ -100,7 +121,9 @@ class InterconnectLinkTopologyFactsModule(object):
                 name = self.module.params.get('name')
                 interconnect_link_topologies = self.oneview_client.interconnect_link_topologies.get_by('name', name)
             else:
-                interconnect_link_topologies = self.oneview_client.interconnect_link_topologies.get_all()
+                params_list = self.module.params.get('params')
+                params = transform_list_to_dict(params_list) if params_list else {}
+                interconnect_link_topologies = self.oneview_client.interconnect_link_topologies.get_all(**params)
 
             self.module.exit_json(changed=False,
                                   ansible_facts=dict(interconnect_link_topologies=interconnect_link_topologies))

--- a/library/oneview_interconnect_type_facts.py
+++ b/library/oneview_interconnect_type_facts.py
@@ -19,6 +19,7 @@
 from ansible.module_utils.basic import *
 try:
     from hpOneView.oneview_client import OneViewClient
+    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
@@ -41,6 +42,15 @@ options:
           The configuration file is optional. If the file path is not provided, the configuration will be loaded from
           environment variables.
       required: false
+    params:
+      description:
+        - List of params to delimit, filter and sort the list of resources.
+        - "params allowed:
+          'start': The first item to return, using 0-based indexing.
+          'count': The number of resources to return.
+          'filter': A general filter/query string to narrow the list of items returned.
+          'sort': The sort order of the returned data set."
+      required: false
     name:
       description:
         - Interconnect Type name.
@@ -56,6 +66,17 @@ EXAMPLES = '''
 - name: Gather facts about all Interconnect Types
   oneview_interconnect_type_facts:
     config: "{{ config_file_path }}"
+
+- debug: var=interconnect_types
+
+- name: Gather paginated, filtered and sorted facts about Interconnect Types
+  oneview_interconnect_type_facts:
+    config: "{{ config_file_path }}"
+    params:
+      - start: 0
+      - count: 3
+      - sort: 'name:descending'
+      - filter: "maximumFirmwareVersion='4000.99'"
 
 - debug: var=interconnect_types
 
@@ -79,7 +100,8 @@ HPE_ONEVIEW_SDK_REQUIRED = 'HPE OneView Python SDK is required for this module.'
 class InterconnectTypeFactsModule(object):
     argument_spec = dict(
         config=dict(required=False, type='str'),
-        name=dict(required=False, type='str')
+        name=dict(required=False, type='str'),
+        params=dict(required=False, type='list'),
     )
 
     def __init__(self):
@@ -110,7 +132,10 @@ class InterconnectTypeFactsModule(object):
                               ansible_facts=dict(interconnect_types=interconnect_types))
 
     def __get_all(self):
-        interconnect_types = self.oneview_client.interconnect_types.get_all()
+        params = self.module.params.get('params')
+        get_all_params = transform_list_to_dict(params) if params else {}
+
+        interconnect_types = self.oneview_client.interconnect_types.get_all(**get_all_params)
 
         self.module.exit_json(changed=False,
                               ansible_facts=dict(interconnect_types=interconnect_types))

--- a/library/oneview_interconnect_type_facts.py
+++ b/library/oneview_interconnect_type_facts.py
@@ -17,9 +17,9 @@
 ###
 
 from ansible.module_utils.basic import *
+
 try:
     from hpOneView.oneview_client import OneViewClient
-    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
@@ -73,10 +73,10 @@ EXAMPLES = '''
   oneview_interconnect_type_facts:
     config: "{{ config_file_path }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: "maximumFirmwareVersion='4000.99'"
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: "maximumFirmwareVersion='4000.99'"
 
 - debug: var=interconnect_types
 
@@ -101,7 +101,7 @@ class InterconnectTypeFactsModule(object):
     argument_spec = dict(
         config=dict(required=False, type='str'),
         name=dict(required=False, type='str'),
-        params=dict(required=False, type='list'),
+        params=dict(required=False, type='dict'),
     )
 
     def __init__(self):
@@ -132,10 +132,9 @@ class InterconnectTypeFactsModule(object):
                               ansible_facts=dict(interconnect_types=interconnect_types))
 
     def __get_all(self):
-        params = self.module.params.get('params')
-        get_all_params = transform_list_to_dict(params) if params else {}
+        params = self.module.params.get('params') or {}
 
-        interconnect_types = self.oneview_client.interconnect_types.get_all(**get_all_params)
+        interconnect_types = self.oneview_client.interconnect_types.get_all(**params)
 
         self.module.exit_json(changed=False,
                               ansible_facts=dict(interconnect_types=interconnect_types))

--- a/library/oneview_internal_link_set_facts.py
+++ b/library/oneview_internal_link_set_facts.py
@@ -19,6 +19,7 @@
 from ansible.module_utils.basic import *
 try:
     from hpOneView.oneview_client import OneViewClient
+    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
@@ -42,6 +43,19 @@ options:
           The configuration file is optional. If the file path is not provided, the configuration will be loaded from
           environment variables.
       required: false
+    params:
+      description:
+        - List of params to delimit, filter and sort the list of resources.
+        - "params allowed:
+          'start': The first item to return, using 0-based indexing.
+          'count': The number of resources to return.
+          'filter': A general filter/query string to narrow the list of items returned.
+          'sort': The sort order of the returned data set.
+          'query': A general query string to narrow the list of resources returned.
+          'fields': Specifies which fields should be returned in the result set.
+          'view': Return a specific subset of the attributes of the resource or collection, by specifying the name
+          of a predefined view."
+      required: false
     name:
       description:
         - Name of the Internal Link Set.
@@ -61,6 +75,15 @@ EXAMPLES = '''
 
 - debug: var=internal_link_sets
 
+- name: Gather paginated and sorted facts about Internal Link Sets
+  oneview_internal_link_set_facts:
+    config: "{{ config_path }}"
+    params:
+      - start: 0
+      - count: 3
+      - sort: 'name:ascending'
+
+- debug: var=internal_link_sets
 
 - name: Gather facts about an Internal Link Set by name
   oneview_internal_link_set_facts:
@@ -83,7 +106,9 @@ HPE_ONEVIEW_SDK_REQUIRED = 'HPE OneView Python SDK is required for this module.'
 class InternalLinkSetFactsModule(object):
     argument_spec = dict(
         config=dict(required=False, type='str'),
-        name=dict(required=False, type='str')
+        name=dict(required=False, type='str'),
+        params=dict(required=False, type='list')
+
     )
 
     def __init__(self):
@@ -101,7 +126,10 @@ class InternalLinkSetFactsModule(object):
             if self.module.params.get('name'):
                 internal_links = self.oneview_client.internal_link_sets.get_by('name', self.module.params.get('name'))
             else:
-                internal_links = self.oneview_client.internal_link_sets.get_all()
+                params = self.module.params.get('params')
+                get_all_params = transform_list_to_dict(params) if params else {}
+
+                internal_links = self.oneview_client.internal_link_sets.get_all(**get_all_params)
 
             self.module.exit_json(changed=False,
                                   ansible_facts=dict(internal_link_sets=internal_links))

--- a/library/oneview_internal_link_set_facts.py
+++ b/library/oneview_internal_link_set_facts.py
@@ -17,9 +17,9 @@
 ###
 
 from ansible.module_utils.basic import *
+
 try:
     from hpOneView.oneview_client import OneViewClient
-    from hpOneView.common import transform_list_to_dict
 
     HAS_HPE_ONEVIEW = True
 except ImportError:
@@ -79,9 +79,9 @@ EXAMPLES = '''
   oneview_internal_link_set_facts:
     config: "{{ config_path }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:ascending'
+      start: 0
+      count: 3
+      sort: 'name:ascending'
 
 - debug: var=internal_link_sets
 
@@ -107,7 +107,7 @@ class InternalLinkSetFactsModule(object):
     argument_spec = dict(
         config=dict(required=False, type='str'),
         name=dict(required=False, type='str'),
-        params=dict(required=False, type='list')
+        params=dict(required=False, type='dict')
 
     )
 
@@ -126,10 +126,9 @@ class InternalLinkSetFactsModule(object):
             if self.module.params.get('name'):
                 internal_links = self.oneview_client.internal_link_sets.get_by('name', self.module.params.get('name'))
             else:
-                params = self.module.params.get('params')
-                get_all_params = transform_list_to_dict(params) if params else {}
+                params = self.module.params.get('params') or {}
 
-                internal_links = self.oneview_client.internal_link_sets.get_all(**get_all_params)
+                internal_links = self.oneview_client.internal_link_sets.get_all(**params)
 
             self.module.exit_json(changed=False,
                                   ansible_facts=dict(internal_link_sets=internal_links))

--- a/oneview-ansible.md
+++ b/oneview-ansible.md
@@ -3077,6 +3077,7 @@ Retrieve facts about the OneView Interconnect Link Topologies.
 | ------------- |-------------| ---------|----------- |--------- |
 | config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of the Interconnect Link Topology.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: 'start': The first item to return, using 0-based indexing. 'count': The number of resources to return. 'filter': A general filter/query string to narrow the list of items returned. 'sort': The sort order of the returned data set.  |
 
 
  
@@ -3089,6 +3090,16 @@ Retrieve facts about the OneView Interconnect Link Topologies.
 
 - debug: var=interconnect_link_topologies
 
+- name: Gather paginated, filtered and sorted facts about Interconnect Link Topologies
+  oneview_interconnect_link_topology_facts:
+    config: "{{ config }}"
+    params:
+      - start: 0
+      - count: 3
+      - sort: 'name:descending'
+      - filter: "name='name1900571853-1483553596802'"
+
+- debug: var=interconnect_link_topologies
 
 - name: Gather facts about an Interconnect Link Topology by name
   oneview_interconnect_link_topology_facts:

--- a/oneview-ansible.md
+++ b/oneview-ansible.md
@@ -1283,10 +1283,10 @@ Retrieve facts about the OneView Connection Templates.
   oneview_connection_template_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'name=defaultConnectionTemplate'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'name=defaultConnectionTemplate'
 
 - debug: var=connection_templates
 
@@ -1459,10 +1459,10 @@ Retrieve facts about the OneView Data Centers.
   oneview_datacenter_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'state=Unmanaged'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'state=Unmanaged'
 
 - debug: var=datacenters
 
@@ -1600,6 +1600,7 @@ Retrieve the facts about one or more of the OneView Drive Enclosures.
 | config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Drive Enclosure name.  |
 | options  |   No  |  | |  List with options to gather additional facts about Drive Enclosure related resources. Options allowed: portMap. To gather additional facts it is required to inform the Drive Enclosure name. Otherwise, these options will be ignored.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: 'start': The first item to return, using 0-based indexing. 'count': The number of resources to return. 'filter': A general filter/query string to narrow the list of items returned. 'sort': The sort order of the returned data set.  |
 
 
  
@@ -1616,10 +1617,10 @@ Retrieve the facts about one or more of the OneView Drive Enclosures.
   oneview_drive_enclosure_facts:
     config: "{{ config_file_path }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'status=Warning'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'status=Warning'
 
 - debug: var=drive_enclosures
 
@@ -1910,10 +1911,10 @@ Retrieve facts about one or more Enclosures.
   oneview_enclosure_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'status=OK'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'status=OK'
 
 - debug: var=enclosures
 
@@ -2096,10 +2097,10 @@ Retrieve facts about one or more of the OneView Enclosure Groups.
   oneview_enclosure_group_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'status=OK'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'status=OK'
 
 - debug: var=enclosure_groups
 
@@ -2274,10 +2275,10 @@ Retrieve the facts about one or more of the OneView Ethernet Networks.
   oneview_ethernet_network_facts:
     config: "{{ config_file_path }}"
     params:
-      - start: 1
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'purpose=General'
+      start: 1
+      count: 3
+      sort: 'name:descending'
+      filter: 'purpose=General'
 
 - debug: var=ethernet_networks
 
@@ -2413,10 +2414,10 @@ Retrieve the facts about one or more of the OneView Fabrics.
   oneview_fabric_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'name=DefaultFabric'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'name=DefaultFabric'
 
 - debug: var=fabrics
 
@@ -2558,10 +2559,10 @@ Retrieve the facts about one or more of the OneView Fibre Channel Networks.
   oneview_fc_network_facts:
     config: "{{ config }}"
     params:
-      - start: 1
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'fabricType=FabricAttach'
+      start: 1
+      count: 3
+      sort: 'name:descending'
+      filter: 'fabricType=FabricAttach'
 - debug: var=fc_networks
 
 - name: Gather facts about a Fibre Channel Network by name
@@ -2685,10 +2686,10 @@ Retrieve the facts about one or more of the OneView FCoE Networks.
   oneview_fcoe_network_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: 'vlanId=2'
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'vlanId=2'
 
 - debug: var=fcoe_networks
 
@@ -2847,9 +2848,9 @@ Retrieve the facts about one or more of the OneView Firmware Drivers.
   oneview_firmware_driver_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
+      start: 0
+      count: 3
+      sort: 'name:descending'
 
 - debug: var=firmware_drivers
 
@@ -2979,10 +2980,10 @@ Retrieve facts about one or more of the OneView Interconnects.
   oneview_interconnect_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 5
-      - sort: 'name:descending'
-      - filter: "enclosureName='0000A66101'"
+      start: 0
+      count: 5
+      sort: 'name:descending'
+      filter: "enclosureName='0000A66101'"
 
 - debug: var=interconnects
 
@@ -3094,10 +3095,10 @@ Retrieve facts about the OneView Interconnect Link Topologies.
   oneview_interconnect_link_topology_facts:
     config: "{{ config }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: "name='name1900571853-1483553596802'"
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: "name='name1900571853-1483553596802'"
 
 - debug: var=interconnect_link_topologies
 
@@ -3164,10 +3165,10 @@ Retrieve facts about one or more of the OneView Interconnect Types.
   oneview_interconnect_type_facts:
     config: "{{ config_file_path }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:descending'
-      - filter: "maximumFirmwareVersion='4000.99'"
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: "maximumFirmwareVersion='4000.99'"
 
 - debug: var=interconnect_types
 
@@ -3232,9 +3233,9 @@ Retrieve facts about the OneView Internal Link Sets.
   oneview_internal_link_set_facts:
     config: "{{ config_path }}"
     params:
-      - start: 0
-      - count: 3
-      - sort: 'name:ascending'
+      start: 0
+      count: 3
+      sort: 'name:ascending'
 
 - debug: var=internal_link_sets
 
@@ -3284,6 +3285,7 @@ Retrieve facts about one or more of the OneView Logical Downlinks.
 | ------------- |-------------| ---------|----------- |--------- |
 | config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Logical Downlink name.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: 'start': The first item to return, using 0-based indexing. 'count': The number of resources to return. 'filter': A general filter/query string to narrow the list of items returned. 'sort': The sort order of the returned data set.  |
 
 
  
@@ -3294,6 +3296,17 @@ Retrieve facts about one or more of the OneView Logical Downlinks.
   oneview_logical_downlinks_facts:
     config: "{{ config }}"
     delegate_to: localhost
+
+- debug: var=logical_downlinks
+
+- name: Gather paginated, filtered and sorted facts about Logical Downlinks
+  oneview_logical_downlinks_facts:
+    config: "{{ config }}"
+    params:
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: "name='LDa4c64fd9-0b76-46c3-8335-0bbb76459aff (Cisco Fabric Extender for HP BladeSystem)'"
 
 - debug: var=logical_downlinks
 

--- a/oneview-ansible.md
+++ b/oneview-ansible.md
@@ -3147,6 +3147,7 @@ Retrieve facts about one or more of the OneView Interconnect Types.
 | ------------- |-------------| ---------|----------- |--------- |
 | config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Interconnect Type name.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: 'start': The first item to return, using 0-based indexing. 'count': The number of resources to return. 'filter': A general filter/query string to narrow the list of items returned. 'sort': The sort order of the returned data set.  |
 
 
  
@@ -3156,6 +3157,17 @@ Retrieve facts about one or more of the OneView Interconnect Types.
 - name: Gather facts about all Interconnect Types
   oneview_interconnect_type_facts:
     config: "{{ config_file_path }}"
+
+- debug: var=interconnect_types
+
+- name: Gather paginated, filtered and sorted facts about Interconnect Types
+  oneview_interconnect_type_facts:
+    config: "{{ config_file_path }}"
+    params:
+      - start: 0
+      - count: 3
+      - sort: 'name:descending'
+      - filter: "maximumFirmwareVersion='4000.99'"
 
 - debug: var=interconnect_types
 

--- a/oneview-ansible.md
+++ b/oneview-ansible.md
@@ -3215,6 +3215,7 @@ Retrieve facts about the OneView Internal Link Sets.
 | ------------- |-------------| ---------|----------- |--------- |
 | config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of the Internal Link Set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: 'start': The first item to return, using 0-based indexing. 'count': The number of resources to return. 'filter': A general filter/query string to narrow the list of items returned. 'sort': The sort order of the returned data set. 'query': A general query string to narrow the list of resources returned. 'fields': Specifies which fields should be returned in the result set. 'view': Return a specific subset of the attributes of the resource or collection, by specifying the name of a predefined view.  |
 
 
  
@@ -3227,6 +3228,15 @@ Retrieve facts about the OneView Internal Link Sets.
 
 - debug: var=internal_link_sets
 
+- name: Gather paginated and sorted facts about Internal Link Sets
+  oneview_internal_link_set_facts:
+    config: "{{ config_path }}"
+    params:
+      - start: 0
+      - count: 3
+      - sort: 'name:ascending'
+
+- debug: var=internal_link_sets
 
 - name: Gather facts about an Internal Link Set by name
   oneview_internal_link_set_facts:

--- a/test/test_oneview_connection_template_facts.py
+++ b/test/test_oneview_connection_template_facts.py
@@ -17,7 +17,7 @@
 import unittest
 
 from oneview_connection_template_facts import ConnectionTemplateFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -41,11 +41,11 @@ PARAMS_GET_DEFAULT = dict(
 )
 
 
-class ConnectionTemplatesFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class ConnectionTemplatesFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, ConnectionTemplateFactsModule)
         self.connection_templates = self.mock_ov_client.connection_templates
-        ParamsTestCase.configure_client_mock(self, self.connection_templates)
+        FactsParamsTestCase.configure_client_mock(self, self.connection_templates)
 
     def test_should_get_all_connection_templates(self):
         self.connection_templates.get_all.return_value = {"name": "Storage System Name"}

--- a/test/test_oneview_datacenter_facts.py
+++ b/test/test_oneview_datacenter_facts.py
@@ -17,7 +17,7 @@
 import unittest
 
 from oneview_datacenter_facts import DatacenterFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -42,11 +42,11 @@ PARAMS_GET_CONNECTED = dict(
 )
 
 
-class DatacentersFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class DatacentersFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, DatacenterFactsModule)
         self.datacenters = self.mock_ov_client.datacenters
-        ParamsTestCase.configure_client_mock(self, self.datacenters)
+        FactsParamsTestCase.configure_client_mock(self, self.datacenters)
 
     def test_should_get_all_datacenters(self):
         self.datacenters.get_all.return_value = {"name": "Data Center Name"}

--- a/test/test_oneview_drive_enclosure_facts.py
+++ b/test/test_oneview_drive_enclosure_facts.py
@@ -17,7 +17,7 @@
 import unittest
 
 from oneview_drive_enclosure_facts import DriveEnclosureFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -61,11 +61,11 @@ PARAMS_GET_BY_NAME_WITH_OPTIONS = dict(
 )
 
 
-class DriveEnclosureFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class DriveEnclosureFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, DriveEnclosureFactsModule)
         self.drive_enclosures = self.mock_ov_client.drive_enclosures
-        ParamsTestCase.configure_client_mock(self, self.drive_enclosures)
+        FactsParamsTestCase.configure_client_mock(self, self.drive_enclosures)
 
     def test_should_get_all(self):
         self.drive_enclosures.get_all.return_value = MOCK_DRIVE_ENCLOSURES

--- a/test/test_oneview_enclosure_facts.py
+++ b/test/test_oneview_enclosure_facts.py
@@ -17,7 +17,7 @@
 import unittest
 
 from oneview_enclosure_facts import EnclosureFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -65,11 +65,11 @@ ENCLOSURE_ENVIRONMENTAL_CONFIG = {
 }
 
 
-class EnclosureFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class EnclosureFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, EnclosureFactsModule)
         self.enclosures = self.mock_ov_client.enclosures
-        ParamsTestCase.configure_client_mock(self, self.enclosures)
+        FactsParamsTestCase.configure_client_mock(self, self.enclosures)
 
     def test_should_get_all_enclosures(self):
         self.enclosures.get_all.return_value = PRESENT_ENCLOSURES

--- a/test/test_oneview_enclosure_group_facts.py
+++ b/test/test_oneview_enclosure_group_facts.py
@@ -17,7 +17,7 @@
 import unittest
 
 from oneview_enclosure_group_facts import EnclosureGroupFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -48,11 +48,11 @@ ENCLOSURE_GROUPS = [{
 }]
 
 
-class EnclosureGroupFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class EnclosureGroupFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, EnclosureGroupFactsModule)
         self.enclosure_groups = self.mock_ov_client.enclosure_groups
-        ParamsTestCase.configure_client_mock(self, self.enclosure_groups)
+        FactsParamsTestCase.configure_client_mock(self, self.enclosure_groups)
 
     def test_should_get_all_enclosure_group(self):
         self.enclosure_groups.get_all.return_value = ENCLOSURE_GROUPS

--- a/test/test_oneview_ethernet_network_facts.py
+++ b/test/test_oneview_ethernet_network_facts.py
@@ -18,7 +18,7 @@ import unittest
 
 from oneview_ethernet_network_facts import EthernetNetworkFactsModule
 from test.utils import ModuleContructorTestCase
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 
 ERROR_MSG = 'Fake message error'
 
@@ -61,11 +61,11 @@ ENET_ASSOCIATED_PROFILES = [dict(uri=ENET_ASSOCIATED_PROFILE_URIS[0], name='Serv
                             dict(uri=ENET_ASSOCIATED_PROFILE_URIS[1], name='Server Profile 2')]
 
 
-class EthernetNetworkFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class EthernetNetworkFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, EthernetNetworkFactsModule)
         self.ethernet_networks = self.mock_ov_client.ethernet_networks
-        ParamsTestCase.configure_client_mock(self, self.ethernet_networks)
+        FactsParamsTestCase.configure_client_mock(self, self.ethernet_networks)
 
     def test_should_get_all_enets(self):
         self.ethernet_networks.get_all.return_value = PRESENT_ENETS

--- a/test/test_oneview_fabric_facts.py
+++ b/test/test_oneview_fabric_facts.py
@@ -17,7 +17,7 @@
 import unittest
 
 from oneview_fabric_facts import FabricFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -60,11 +60,11 @@ DEFAULT_FABRIC_VLAN_RANGE = dict(
 )
 
 
-class FabricFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class FabricFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, FabricFactsModule)
         self.fabrics = self.mock_ov_client.fabrics
-        ParamsTestCase.configure_client_mock(self, self.fabrics)
+        FactsParamsTestCase.configure_client_mock(self, self.fabrics)
 
     def test_should_get_all(self):
         self.fabrics.get_all.return_value = PRESENT_FABRICS

--- a/test/test_oneview_fc_network_facts.py
+++ b/test/test_oneview_fc_network_facts.py
@@ -17,7 +17,7 @@
 import unittest
 
 from oneview_fc_network_facts import FcNetworkFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -38,11 +38,11 @@ PRESENT_NETWORKS = [{
 }]
 
 
-class FcNetworkFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class FcNetworkFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, FcNetworkFactsModule)
         self.fc_networks = self.mock_ov_client.fc_networks
-        ParamsTestCase.configure_client_mock(self, self.fc_networks)
+        FactsParamsTestCase.configure_client_mock(self, self.fc_networks)
 
     def test_should_get_all_fc_networks(self):
         self.fc_networks.get_all.return_value = PRESENT_NETWORKS

--- a/test/test_oneview_fcoe_network_facts.py
+++ b/test/test_oneview_fcoe_network_facts.py
@@ -17,7 +17,7 @@
 import unittest
 
 from oneview_fcoe_network_facts import FcoeNetworkFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -38,11 +38,11 @@ PRESENT_NETWORKS = [{
 }]
 
 
-class FcoeNetworkFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class FcoeNetworkFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, FcoeNetworkFactsModule)
         self.fcoe_networks = self.mock_ov_client.fcoe_networks
-        ParamsTestCase.configure_client_mock(self, self.fcoe_networks)
+        FactsParamsTestCase.configure_client_mock(self, self.fcoe_networks)
 
     def test_should_get_all_fcoe_network(self):
         self.fcoe_networks.get_all.return_value = PRESENT_NETWORKS

--- a/test/test_oneview_firmware_driver_facts.py
+++ b/test/test_oneview_firmware_driver_facts.py
@@ -17,7 +17,7 @@
 import unittest
 
 from oneview_firmware_driver_facts import FirmwareDriverFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 FIRMWARE_DRIVER_NAME = "Service Pack for ProLiant.iso"
@@ -39,11 +39,11 @@ FIRMWARE_DRIVER = dict(
 )
 
 
-class FirmwareDriverFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class FirmwareDriverFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, FirmwareDriverFactsModule)
         self.firmware_drivers = self.mock_ov_client.firmware_drivers
-        ParamsTestCase.configure_client_mock(self, self.firmware_drivers)
+        FactsParamsTestCase.configure_client_mock(self, self.firmware_drivers)
 
     def test_should_get_all_firmware_drivers(self):
         firmwares = [FIRMWARE_DRIVER]

--- a/test/test_oneview_interconnect_facts.py
+++ b/test/test_oneview_interconnect_facts.py
@@ -17,7 +17,7 @@
 import unittest
 
 from oneview_interconnect_facts import InterconnectFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -67,11 +67,11 @@ MOCK_INTERCONNECTS = [
 ]
 
 
-class InterconnectFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class InterconnectFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, InterconnectFactsModule)
         self.interconnects = self.mock_ov_client.interconnects
-        ParamsTestCase.configure_client_mock(self, self.interconnects)
+        FactsParamsTestCase.configure_client_mock(self, self.interconnects)
 
     def test_should_get_all_interconnects(self):
         fake_interconnects = [dict(uidState='On', name=INTERCONNECT_NAME)]

--- a/test/test_oneview_interconnect_link_topology_facts.py
+++ b/test/test_oneview_interconnect_link_topology_facts.py
@@ -15,11 +15,10 @@
 ###
 
 import unittest
-import mock
 
-from hpOneView.oneview_client import OneViewClient
 from oneview_interconnect_link_topology_facts import InterconnectLinkTopologyFactsModule
-from test.utils import create_ansible_mock
+from test.utils import ParamsTestCase
+from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
 
@@ -38,106 +37,53 @@ INTERCONNECT_LINK_TOPOLOGIES = [{"name": "Interconnect Link Topology 1"},
                                 {"name": "Interconnect Link Topology 3"}]
 
 
-class InterconnectLinkTopologyFactsClientConfigurationSpec(unittest.TestCase):
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch.object(OneViewClient, 'from_environment_variables')
-    @mock.patch('oneview_interconnect_link_topology_facts.AnsibleModule')
-    def test_should_load_config_from_file(self, mock_ansible_module, mock_ov_client_from_env_vars,
-                                          mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_client_from_json_file.return_value = mock_ov_instance
-        mock_ansible_instance = create_ansible_mock({'config': 'config.json'})
-        mock_ansible_module.return_value = mock_ansible_instance
+class InterconnectLinkTopologyFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, InterconnectLinkTopologyFactsModule)
+        self.interconnect_link_topologies = self.mock_ov_client.interconnect_link_topologies
+        ParamsTestCase.configure_client_mock(self, self.interconnect_link_topologies)
 
-        InterconnectLinkTopologyFactsModule()
+    def test_should_get_all_interconnect_link_topologies(self):
+        self.interconnect_link_topologies.get_all.return_value = INTERCONNECT_LINK_TOPOLOGIES
 
-        mock_ov_client_from_json_file.assert_called_once_with('config.json')
-        mock_ov_client_from_env_vars.not_been_called()
-
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch.object(OneViewClient, 'from_environment_variables')
-    @mock.patch('oneview_interconnect_link_topology_facts.AnsibleModule')
-    def test_should_load_config_from_environment(self, mock_ansible_module, mock_ov_client_from_env_vars,
-                                                 mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-
-        mock_ov_client_from_env_vars.return_value = mock_ov_instance
-        mock_ansible_instance = create_ansible_mock({'config': None})
-        mock_ansible_module.return_value = mock_ansible_instance
-
-        InterconnectLinkTopologyFactsModule()
-
-        mock_ov_client_from_env_vars.assert_called_once()
-        mock_ov_client_from_json_file.not_been_called()
-
-
-class InterconnectLinkTopologyFactsSpec(unittest.TestCase):
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_interconnect_link_topology_facts.AnsibleModule')
-    def test_should_get_all_interconnect_link_topologies(self, mock_ansible_module, mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.interconnect_link_topologies.get_all.return_value = INTERCONNECT_LINK_TOPOLOGIES
-
-        mock_ov_client_from_json_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_ALL)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_GET_ALL
 
         InterconnectLinkTopologyFactsModule().run()
 
-        mock_ansible_instance.exit_json.assert_called_once_with(
+        self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(interconnect_link_topologies=(INTERCONNECT_LINK_TOPOLOGIES))
         )
 
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_interconnect_link_topology_facts.AnsibleModule')
-    def test_should_fail_when_get_all_raises_exception(self, mock_ansible_module, mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.interconnect_link_topologies.get_all.side_effect = Exception(ERROR_MSG)
+    def test_should_fail_when_get_all_raises_exception(self):
+        self.interconnect_link_topologies.get_all.side_effect = Exception(ERROR_MSG)
 
-        mock_ov_client_from_json_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_ALL)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_GET_ALL
 
         InterconnectLinkTopologyFactsModule().run()
 
-        mock_ansible_instance.fail_json.assert_called_once()
+        self.mock_ansible_module.fail_json.assert_called_once()
 
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_interconnect_link_topology_facts.AnsibleModule')
-    def test_should_get_all_interconnect_link_topology_by_name(self, mock_ansible_module,
-                                                               mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.interconnect_link_topologies.get_by.return_value = [INTERCONNECT_LINK_TOPOLOGIES[1]]
+    def test_should_get_all_interconnect_link_topology_by_name(self):
+        self.interconnect_link_topologies.get_by.return_value = [INTERCONNECT_LINK_TOPOLOGIES[1]]
 
-        mock_ov_client_from_json_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_BY_NAME)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
 
         InterconnectLinkTopologyFactsModule().run()
 
-        mock_ansible_instance.exit_json.assert_called_once_with(
+        self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(interconnect_link_topologies=([INTERCONNECT_LINK_TOPOLOGIES[1]]))
         )
 
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_interconnect_link_topology_facts.AnsibleModule')
-    def test_should_fail_when_get_by_name_raises_exception(self, mock_ansible_module, mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.interconnect_link_topologies.get_by.side_effect = Exception(ERROR_MSG)
+    def test_should_fail_when_get_by_name_raises_exception(self):
+        self.interconnect_link_topologies.get_by.side_effect = Exception(ERROR_MSG)
 
-        mock_ov_client_from_json_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_BY_NAME)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
 
         InterconnectLinkTopologyFactsModule().run()
 
-        mock_ansible_instance.fail_json.assert_called_once()
+        self.mock_ansible_module.fail_json.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/test/test_oneview_interconnect_link_topology_facts.py
+++ b/test/test_oneview_interconnect_link_topology_facts.py
@@ -17,7 +17,7 @@
 import unittest
 
 from oneview_interconnect_link_topology_facts import InterconnectLinkTopologyFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -37,11 +37,11 @@ INTERCONNECT_LINK_TOPOLOGIES = [{"name": "Interconnect Link Topology 1"},
                                 {"name": "Interconnect Link Topology 3"}]
 
 
-class InterconnectLinkTopologyFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class InterconnectLinkTopologyFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, InterconnectLinkTopologyFactsModule)
         self.interconnect_link_topologies = self.mock_ov_client.interconnect_link_topologies
-        ParamsTestCase.configure_client_mock(self, self.interconnect_link_topologies)
+        FactsParamsTestCase.configure_client_mock(self, self.interconnect_link_topologies)
 
     def test_should_get_all_interconnect_link_topologies(self):
         self.interconnect_link_topologies.get_all.return_value = INTERCONNECT_LINK_TOPOLOGIES

--- a/test/test_oneview_interconnect_type_facts.py
+++ b/test/test_oneview_interconnect_type_facts.py
@@ -16,7 +16,7 @@
 
 import unittest
 from oneview_interconnect_type_facts import InterconnectTypeFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -37,11 +37,11 @@ PRESENT_TYPES = [{
 }]
 
 
-class InterconnectTypeFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class InterconnectTypeFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, InterconnectTypeFactsModule)
         self.interconnect_types = self.mock_ov_client.interconnect_types
-        ParamsTestCase.configure_client_mock(self, self.interconnect_types)
+        FactsParamsTestCase.configure_client_mock(self, self.interconnect_types)
 
     def test_should_get_all_interconnect_types(self):
         self.interconnect_types.get_all.return_value = PRESENT_TYPES

--- a/test/test_oneview_interconnect_type_facts.py
+++ b/test/test_oneview_interconnect_type_facts.py
@@ -15,11 +15,9 @@
 ###
 
 import unittest
-import mock
-
-from hpOneView.oneview_client import OneViewClient
 from oneview_interconnect_type_facts import InterconnectTypeFactsModule
-from test.utils import create_ansible_mock
+from test.utils import ParamsTestCase
+from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
 
@@ -39,107 +37,53 @@ PRESENT_TYPES = [{
 }]
 
 
-class InterconnectTypeFactsClientConfigurationSpec(unittest.TestCase):
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch.object(OneViewClient, 'from_environment_variables')
-    @mock.patch('oneview_interconnect_type_facts.AnsibleModule')
-    def test_should_load_config_from_file(self, mock_ansible_module, mock_ov_client_from_env_vars,
-                                          mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_client_from_json_file.return_value = mock_ov_instance
-        mock_ansible_instance = create_ansible_mock({'config': 'config.json'})
-        mock_ansible_module.return_value = mock_ansible_instance
+class InterconnectTypeFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, InterconnectTypeFactsModule)
+        self.interconnect_types = self.mock_ov_client.interconnect_types
+        ParamsTestCase.configure_client_mock(self, self.interconnect_types)
 
-        InterconnectTypeFactsModule()
+    def test_should_get_all_interconnect_types(self):
+        self.interconnect_types.get_all.return_value = PRESENT_TYPES
 
-        mock_ov_client_from_json_file.assert_called_once_with('config.json')
-        mock_ov_client_from_env_vars.not_been_called()
-
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch.object(OneViewClient, 'from_environment_variables')
-    @mock.patch('oneview_interconnect_type_facts.AnsibleModule')
-    def test_should_load_config_from_environment(self, mock_ansible_module, mock_ov_client_from_env_vars,
-                                                 mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-
-        mock_ov_client_from_env_vars.return_value = mock_ov_instance
-        mock_ansible_instance = create_ansible_mock({'config': None})
-        mock_ansible_module.return_value = mock_ansible_instance
-
-        InterconnectTypeFactsModule()
-
-        mock_ov_client_from_env_vars.assert_called_once()
-        mock_ov_client_from_json_file.not_been_called()
-
-
-class InterconnectTypeFactsSpec(unittest.TestCase):
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_interconnect_type_facts.AnsibleModule')
-    def test_should_get_all_interconnect_types(self, mock_ansible_module,
-                                               mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.interconnect_types.get_all.return_value = PRESENT_TYPES
-
-        mock_ov_client_from_json_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_ALL)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_GET_ALL
 
         InterconnectTypeFactsModule().run()
 
-        mock_ansible_instance.exit_json.assert_called_once_with(
+        self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(interconnect_types=(PRESENT_TYPES))
         )
 
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_interconnect_type_facts.AnsibleModule')
-    def test_should_fail_when_get_all_raises_exception(self, mock_ansible_module, mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.interconnect_types.get_all.side_effect = Exception(ERROR_MSG)
+    def test_should_fail_when_get_all_raises_exception(self):
+        self.interconnect_types.get_all.side_effect = Exception(ERROR_MSG)
 
-        mock_ov_client_from_json_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_ALL)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_GET_ALL
 
         InterconnectTypeFactsModule().run()
 
-        mock_ansible_instance.fail_json.assert_called_once()
+        self.mock_ansible_module.fail_json.assert_called_once()
 
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_interconnect_type_facts.AnsibleModule')
-    def test_should_get_interconnect_type_by_name(self, mock_ansible_module,
-                                                  mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.interconnect_types.get_by.return_value = PRESENT_TYPES
+    def test_should_get_interconnect_type_by_name(self):
+        self.interconnect_types.get_by.return_value = PRESENT_TYPES
 
-        mock_ov_client_from_json_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_BY_NAME)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
 
         InterconnectTypeFactsModule().run()
 
-        mock_ansible_instance.exit_json.assert_called_once_with(
+        self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(interconnect_types=(PRESENT_TYPES))
         )
 
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_interconnect_type_facts.AnsibleModule')
-    def test_should_fail_when_get_by_name_raises_exception(self, mock_ansible_module, mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.interconnect_types.get_by.side_effect = Exception(ERROR_MSG)
+    def test_should_fail_when_get_by_name_raises_exception(self):
+        self.interconnect_types.get_by.side_effect = Exception(ERROR_MSG)
 
-        mock_ov_client_from_json_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_BY_NAME)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
 
         InterconnectTypeFactsModule().run()
 
-        mock_ansible_instance.fail_json.assert_called_once()
+        self.mock_ansible_module.fail_json.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/test/test_oneview_internal_link_set_facts.py
+++ b/test/test_oneview_internal_link_set_facts.py
@@ -16,7 +16,7 @@
 
 import unittest
 from oneview_internal_link_set_facts import InternalLinkSetFactsModule
-from test.utils import ParamsTestCase
+from test.utils import FactsParamsTestCase
 from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
@@ -34,11 +34,11 @@ PARAMS_GET_BY_NAME = dict(
 INTERNAL_LINK_SETS = [{"name": "ILS56"}, {"name": "ILS58"}, {"name": "ILS100"}]
 
 
-class InternalLinkSetFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
+class InternalLinkSetFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
     def setUp(self):
         self.configure_mocks(self, InternalLinkSetFactsModule)
         self.internal_link_sets = self.mock_ov_client.internal_link_sets
-        ParamsTestCase.configure_client_mock(self, self.internal_link_sets)
+        FactsParamsTestCase.configure_client_mock(self, self.internal_link_sets)
 
     def test_should_get_all_internal_link_sets(self):
         self.internal_link_sets.get_all.return_value = INTERNAL_LINK_SETS

--- a/test/test_oneview_internal_link_set_facts.py
+++ b/test/test_oneview_internal_link_set_facts.py
@@ -15,11 +15,9 @@
 ###
 
 import unittest
-import mock
-
-from hpOneView.oneview_client import OneViewClient
 from oneview_internal_link_set_facts import InternalLinkSetFactsModule
-from test.utils import create_ansible_mock
+from test.utils import ParamsTestCase
+from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
 
@@ -36,100 +34,49 @@ PARAMS_GET_BY_NAME = dict(
 INTERNAL_LINK_SETS = [{"name": "ILS56"}, {"name": "ILS58"}, {"name": "ILS100"}]
 
 
-class InternalLinkSetFactsClientConfigurationSpec(unittest.TestCase):
+class InternalLinkSetFactsSpec(unittest.TestCase, ModuleContructorTestCase, ParamsTestCase):
     def setUp(self):
-        self.patcher_ansible_module = mock.patch('oneview_internal_link_set_facts.AnsibleModule')
-        self.mock_ansible_module = self.patcher_ansible_module.start()
-
-        self.patcher_ov_client_from_env_vars = mock.patch.object(OneViewClient, 'from_environment_variables')
-        self.mock_ov_client_from_env_vars = self.patcher_ov_client_from_env_vars.start()
-
-        self.patcher_ov_client_from_json_file = mock.patch.object(OneViewClient, 'from_json_file')
-        self.mock_ov_client_from_json_file = self.patcher_ov_client_from_json_file.start()
-
-    def tearDown(self):
-        self.patcher_ansible_module.stop()
-        self.patcher_ov_client_from_env_vars.stop()
-        self.patcher_ov_client_from_json_file.stop()
-
-    def test_should_load_config_from_file(self):
-        mock_ansible_instance = create_ansible_mock({'config': 'config.json'})
-        self.mock_ansible_module.return_value = mock_ansible_instance
-
-        InternalLinkSetFactsModule()
-
-        self.mock_ov_client_from_json_file.assert_called_once_with('config.json')
-        self.mock_ov_client_from_env_vars.not_been_called()
-
-    def test_should_load_config_from_environment(self):
-        mock_ov_instance = mock.Mock()
-
-        self.mock_ov_client_from_env_vars.return_value = mock_ov_instance
-        mock_ansible_instance = create_ansible_mock({'config': None})
-        self.mock_ansible_module.return_value = mock_ansible_instance
-
-        InternalLinkSetFactsModule()
-
-        self.mock_ov_client_from_env_vars.assert_called_once()
-        self.mock_ov_client_from_json_file.not_been_called()
-
-
-class InternalLinkSetFactsSpec(unittest.TestCase):
-    def setUp(self):
-        self.patcher_ansible_module = mock.patch('oneview_internal_link_set_facts.AnsibleModule')
-        self.mock_ansible_module = self.patcher_ansible_module.start()
-
-        self.patcher_ov_client_from_json_file = mock.patch.object(OneViewClient, 'from_json_file')
-        self.mock_ov_client_from_json_file = self.patcher_ov_client_from_json_file.start()
-
-        self.mock_ov_instance = mock.Mock()
-        self.mock_ov_client_from_json_file.return_value = self.mock_ov_instance
-
-    def tearDown(self):
-        self.patcher_ansible_module.stop()
-        self.patcher_ov_client_from_json_file.stop()
+        self.configure_mocks(self, InternalLinkSetFactsModule)
+        self.internal_link_sets = self.mock_ov_client.internal_link_sets
+        ParamsTestCase.configure_client_mock(self, self.internal_link_sets)
 
     def test_should_get_all_internal_link_sets(self):
-        self.mock_ov_instance.internal_link_sets.get_all.return_value = INTERNAL_LINK_SETS
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_ALL)
-        self.mock_ansible_module.return_value = mock_ansible_instance
+        self.internal_link_sets.get_all.return_value = INTERNAL_LINK_SETS
+        self.mock_ansible_module.params = PARAMS_GET_ALL
 
         InternalLinkSetFactsModule().run()
 
-        mock_ansible_instance.exit_json.assert_called_once_with(
+        self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(internal_link_sets=(INTERNAL_LINK_SETS))
         )
 
     def test_should_fail_when_get_all_raises_exception(self):
-        self.mock_ov_instance.internal_link_sets.get_all.side_effect = Exception(ERROR_MSG)
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_ALL)
-        self.mock_ansible_module.return_value = mock_ansible_instance
+        self.internal_link_sets.get_all.side_effect = Exception(ERROR_MSG)
+        self.mock_ansible_module.params = PARAMS_GET_ALL
 
         InternalLinkSetFactsModule().run()
 
-        mock_ansible_instance.fail_json.assert_called_once()
+        self.mock_ansible_module.fail_json.assert_called_once()
 
     def test_should_get_by_name(self):
-        self.mock_ov_instance.internal_link_sets.get_by.return_value = [INTERNAL_LINK_SETS[1]]
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_BY_NAME)
-        self.mock_ansible_module.return_value = mock_ansible_instance
+        self.internal_link_sets.get_by.return_value = [INTERNAL_LINK_SETS[1]]
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
 
         InternalLinkSetFactsModule().run()
 
-        mock_ansible_instance.exit_json.assert_called_once_with(
+        self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(internal_link_sets=([INTERNAL_LINK_SETS[1]]))
         )
 
     def test_should_fail_when_get_by_name_raises_exception(self):
-        self.mock_ov_instance.internal_link_sets.get_by.side_effect = Exception(ERROR_MSG)
-        mock_ansible_instance = create_ansible_mock(PARAMS_GET_BY_NAME)
-        self.mock_ansible_module.return_value = mock_ansible_instance
+        self.internal_link_sets.get_by.side_effect = Exception(ERROR_MSG)
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
 
         InternalLinkSetFactsModule().run()
 
-        mock_ansible_instance.fail_json.assert_called_once()
+        self.mock_ansible_module.fail_json.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/test/test_oneview_logical_downlinks_facts.py
+++ b/test/test_oneview_logical_downlinks_facts.py
@@ -15,13 +15,9 @@
 ###
 
 import unittest
-import mock
-
-from utils import create_ansible_mock
-
-from hpOneView.oneview_client import OneViewClient
 from oneview_logical_downlinks_facts import LogicalDownlinksFactsModule
-
+from test.utils import FactsParamsTestCase
+from test.utils import ModuleContructorTestCase
 
 ERROR_MSG = 'Fake message error'
 
@@ -55,161 +51,96 @@ PARAMS_FOR_GET_WITHOUT_ETHERNET = dict(
 )
 
 
-class LogicalDownlinkFactsClientConfigurationSpec(unittest.TestCase):
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch.object(OneViewClient, 'from_environment_variables')
-    @mock.patch('oneview_logical_downlinks_facts.AnsibleModule')
-    def test_should_load_config_from_file(self, mock_ansible_module, mock_ov_client_from_env_vars,
-                                          mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_client_from_json_file.return_value = mock_ov_instance
-        mock_ansible_instance = create_ansible_mock({'config': 'config.json'})
-        mock_ansible_module.return_value = mock_ansible_instance
+class LogicalDownlinksFactsSpec(unittest.TestCase, ModuleContructorTestCase, FactsParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, LogicalDownlinksFactsModule)
+        self.logical_downlinks = self.mock_ov_client.logical_downlinks
+        self.configure_client_mock(self.logical_downlinks)
 
-        LogicalDownlinksFactsModule()
-
-        mock_ov_client_from_json_file.assert_called_once_with('config.json')
-        mock_ov_client_from_env_vars.not_been_called()
-
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch.object(OneViewClient, 'from_environment_variables')
-    @mock.patch('oneview_logical_downlinks_facts.AnsibleModule')
-    def test_should_load_config_from_environment(self, mock_ansible_module, mock_ov_client_from_env_vars,
-                                                 mock_ov_client_from_json_file):
-        mock_ov_instance = mock.Mock()
-
-        mock_ov_client_from_env_vars.return_value = mock_ov_instance
-        mock_ansible_instance = create_ansible_mock({'config': None})
-        mock_ansible_module.return_value = mock_ansible_instance
-
-        LogicalDownlinksFactsModule()
-
-        mock_ov_client_from_env_vars.assert_called_once()
-        mock_ov_client_from_json_file.not_been_called()
-
-
-class LogicalDownlinksFactsSpec(unittest.TestCase):
-
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_logical_downlinks_facts.AnsibleModule')
-    def test_should_get_all_logical_downlinks(self, mock_ansible_module, mock_ov_from_file):
+    def test_should_get_all_logical_downlinks(self):
         logical_downlinks = [
             dict(name="test1"),
             dict(name="test2")
         ]
 
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.logical_downlinks.get_all.return_value = logical_downlinks
+        self.logical_downlinks.get_all.return_value = logical_downlinks
 
-        mock_ov_from_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_FOR_GET_ALL)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_FOR_GET_ALL
 
         LogicalDownlinksFactsModule().run()
 
-        mock_ov_instance.logical_downlinks.get_all.assert_called_once()
+        self.logical_downlinks.get_all.assert_called_once()
 
-        mock_ansible_instance.exit_json.assert_called_once_with(
+        self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(logical_downlinks=logical_downlinks)
         )
 
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_logical_downlinks_facts.AnsibleModule')
-    def test_should_fail_when_get_all_raises_exception(self, mock_ansible_module, mock_ov_from_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.logical_downlinks.get_all.side_effect = Exception(ERROR_MSG)
+    def test_should_fail_when_get_all_raises_exception(self):
+        self.logical_downlinks.get_all.side_effect = Exception(ERROR_MSG)
 
-        mock_ov_from_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_FOR_GET_ALL)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_FOR_GET_ALL
 
         LogicalDownlinksFactsModule().run()
 
-        mock_ansible_instance.fail_json.assert_called_once_with(msg=ERROR_MSG)
+        self.mock_ansible_module.fail_json.assert_called_once_with(msg=ERROR_MSG)
 
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_logical_downlinks_facts.AnsibleModule')
-    def test_should_get_by_name(self, mock_ansible_module, mock_ov_from_file):
+    def test_should_get_by_name(self):
         logical_downlinks = [LOGICAL_DOWNLINK]
 
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.logical_downlinks.get_by.return_value = logical_downlinks
+        self.logical_downlinks.get_by.return_value = logical_downlinks
 
-        mock_ov_from_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_FOR_GET_BY_NAME)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_FOR_GET_BY_NAME
 
         LogicalDownlinksFactsModule().run()
 
-        mock_ov_instance.logical_downlinks.get_by.assert_called_once_with("name", LOGICAL_DOWNLINK_NAME)
+        self.logical_downlinks.get_by.assert_called_once_with("name", LOGICAL_DOWNLINK_NAME)
 
-        mock_ansible_instance.exit_json.assert_called_once_with(
+        self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(logical_downlinks=logical_downlinks)
         )
 
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_logical_downlinks_facts.AnsibleModule')
-    def test_should_fail_when_get_by_raises_exception(self, mock_ansible_module, mock_ov_from_file):
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.logical_downlinks.get_by.side_effect = Exception(ERROR_MSG)
+    def test_should_fail_when_get_by_raises_exception(self):
+        self.logical_downlinks.get_by.side_effect = Exception(ERROR_MSG)
 
-        mock_ov_from_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_FOR_GET_BY_NAME)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_FOR_GET_BY_NAME
 
         LogicalDownlinksFactsModule().run()
 
-        mock_ansible_instance.fail_json.assert_called_once_with(msg=ERROR_MSG)
+        self.mock_ansible_module.fail_json.assert_called_once_with(msg=ERROR_MSG)
 
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_logical_downlinks_facts.AnsibleModule')
-    def test_should_get_all_without_ethernet(self, mock_ansible_module, mock_ov_from_file):
+    def test_should_get_all_without_ethernet(self):
         logical_downlinks = [LOGICAL_DOWNLINK]
 
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.logical_downlinks.get_all_without_ethernet.return_value = logical_downlinks
+        self.logical_downlinks.get_all_without_ethernet.return_value = logical_downlinks
 
-        mock_ov_from_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_FOR_GET_ALL_WITHOUT_ETHERNET)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_FOR_GET_ALL_WITHOUT_ETHERNET
 
         LogicalDownlinksFactsModule().run()
 
-        mock_ov_instance.logical_downlinks.get_all_without_ethernet.assert_called_once()
+        self.logical_downlinks.get_all_without_ethernet.assert_called_once()
 
-        mock_ansible_instance.exit_json.assert_called_once_with(
+        self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(logical_downlinks=logical_downlinks)
         )
 
-    @mock.patch.object(OneViewClient, 'from_json_file')
-    @mock.patch('oneview_logical_downlinks_facts.AnsibleModule')
-    def test_should_get_without_ethernet(self, mock_ansible_module, mock_ov_from_file):
+    def test_should_get_without_ethernet(self):
         logical_downlinks = [LOGICAL_DOWNLINK]
         logical_downlinks_without_ethernet = []
 
-        mock_ov_instance = mock.Mock()
-        mock_ov_instance.logical_downlinks.get_by.return_value = logical_downlinks
-        mock_ov_instance.logical_downlinks.get_without_ethernet.return_value = logical_downlinks_without_ethernet
+        self.logical_downlinks.get_by.return_value = logical_downlinks
+        self.logical_downlinks.get_without_ethernet.return_value = logical_downlinks_without_ethernet
 
-        mock_ov_from_file.return_value = mock_ov_instance
-
-        mock_ansible_instance = create_ansible_mock(PARAMS_FOR_GET_WITHOUT_ETHERNET)
-        mock_ansible_module.return_value = mock_ansible_instance
+        self.mock_ansible_module.params = PARAMS_FOR_GET_WITHOUT_ETHERNET
 
         LogicalDownlinksFactsModule().run()
 
-        mock_ov_instance.logical_downlinks.get_by.assert_called_once_with('name', LOGICAL_DOWNLINK_NAME)
-        mock_ov_instance.logical_downlinks.get_without_ethernet.assert_called_once_with(id_or_uri=LOGICAL_DOWNLINK_URI)
+        self.logical_downlinks.get_by.assert_called_once_with('name', LOGICAL_DOWNLINK_NAME)
+        self.logical_downlinks.get_without_ethernet.assert_called_once_with(id_or_uri=LOGICAL_DOWNLINK_URI)
 
-        mock_ansible_instance.exit_json.assert_called_once_with(
+        self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(logical_downlinks=logical_downlinks_without_ethernet)
         )

--- a/test/utils.py
+++ b/test/utils.py
@@ -158,7 +158,7 @@ class ValidateEtagTestCase(PreloadedMocksBaseTestCase):
         self.mock_ov_client.connection.disable_etag_validation.assert_called_once()
 
 
-class ParamsTestCase(PreloadedMocksBaseTestCase):
+class FactsParamsTestCase(PreloadedMocksBaseTestCase):
     """
     ParamsTestCase has common test for classes that support pass additional parameters when retrieving all resources.
     """
@@ -168,33 +168,32 @@ class ParamsTestCase(PreloadedMocksBaseTestCase):
         Args:
              resorce_client: Resource client that is being called
         """
-        self.__resorce_client = resorce_client
+        self._resource_client = resorce_client
 
     def __validations(self):
         if not self._testing_class:
             raise Exception("Mocks are not configured, you must call 'configure_mocks' before running this test.")
 
-        if not self.__resorce_client:
+        if not self._resource_client:
             raise Exception(
                 "Mock for the client not configured, you must call 'configure_client_mock' before running this test.")
 
     def test_should_get_all_using_filters(self):
         self.__validations()
-        self.__resorce_client.get_all.return_value = []
+        self._resource_client.get_all.return_value = []
 
         params_get_all_with_filters = dict(
             config='config.json',
             name=None,
-            params=[
-                {'start': 1,
-                 'count': 3,
-                 'sort': 'name:descending',
-                 'filter': 'purpose=General'}
-            ]
-        )
+            params={
+                'start': 1,
+                'count': 3,
+                'sort': 'name:descending',
+                'filter': 'purpose=General'
+            })
         self.mock_ansible_module.params = params_get_all_with_filters
 
         self._testing_class().run()
 
-        self.__resorce_client.get_all.assert_called_once_with(start=1, count=3, sort='name:descending',
+        self._resource_client.get_all.assert_called_once_with(start=1, count=3, sort='name:descending',
                                                               filter='purpose=General')


### PR DESCRIPTION
Add support for filters for:

-  oneview_interconnect_link_topology_facts		
-   oneview_interconnect_type_facts		
-   oneview_internal_link_set_facts

Change the type of the option 'param' to dict