### PR TITLE
Adding an example to create Server Profile from Template using NIC Custom Attributes

### DIFF
--- a/examples/synergy_create_server_profile_with_deployment_plan.yml
+++ b/examples/synergy_create_server_profile_with_deployment_plan.yml
@@ -1,0 +1,58 @@
+###
+# Copyright (2017) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+---
+###
+# This playbook is only compatible with HPE Synergy Enclosures
+###
+- name: Deploy Server Profile from Template, selecting the right connection for Management NIC
+  hosts: all
+  gather_facts: no
+  vars:
+    - config: "{{ playbook_dir }}/oneview_config.json"
+    - deployment_plan_name: 'update-nodejs-stack-RHEL7.2'
+    - management_network_name: 'mgmt'
+    - server_template_name: 'webserver-template'
+
+  tasks:
+    - name: Gather facts about the Server Profile Template to retrieve connection information
+      oneview_server_profile_template_facts:
+        config: "{{ config }}"
+        name: "{{ server_template_name }}"
+      delegate_to: localhost
+
+    - name: Find the connection by management network name
+      set_fact: connection={{ server_profile_templates.0.connections | selectattr('name', 'equalto', management_network_name) | first }}
+
+    - name : "Create server profile with deployment plan {{ deployment_plan_name }}"
+      delegate_to: localhost
+      oneview_server_profile:
+        config: "{{ config }}"
+        data:
+            name: "{{ inventory_hostname }}"
+            server_template: "{{ server_template_name }}"
+            osDeploymentSettings:
+              osDeploymentPlanName: "{{ deployment_plan_name }}"
+              osCustomAttributes:
+                -  name: MgmtNIC1.connectionid
+                   value: '{{ connection.id }}'
+                -  name: MgmtNIC1.dhcp
+                   value: false
+                -  name: MgmtNIC1.ipv4disable
+                   value: false
+                -  name: MgmtNIC1.networkuri
+                   value: '{{ connection.networkUri }}'
+                -  name: MgmtNIC1.constraint
+                   value: auto

--- a/library/oneview_server_profile_template_facts.py
+++ b/library/oneview_server_profile_template_facts.py
@@ -156,7 +156,7 @@ class ServerProfileTemplateFactsModule(object):
 
         facts = dict(server_profile_templates=[template])
 
-        options = self.module.params["options"]
+        options = self.module.params.get("options")
 
         if options:
             options = transform_list_to_dict(options)


### PR DESCRIPTION
Adding an example to create Server Profile from Template.
It selects the right connection for Management NIC, this connection is used to fill the custom attributes.