### PR TITLE
Build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - 2.7
+  - 3.5
 install:
   - pip install ansible==2.1.1.0
   - pip install git+https://github.com/sivel/ansible-testing.git#egg=ansible_testing
@@ -13,4 +14,3 @@ script:
   - export PYTHONPATH=$ANSIBLE_LIBRARY:$PYTHONPATH
   - touch examples/vars/config.yml
   - ./build.sh
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,28 @@ language: python
 python:
   - 2.7
   - 3.5
+env:
+  - ANSIBLE=2.1 PYPI_VERSION='2.1.5.0'
+  - ANSIBLE=2.2 PYPI_VERSION='2.2.2.0'
+  - ANSIBLE=2.3 PYPI_VERSION='2.3.0.0'
+  - ANSIBLE=src-2.3 BRANCH='stable-2.3'  # source code is required to run the sanity test validate-modules
 install:
-  - pip install ansible==2.1.1.0
-  - pip install git+https://github.com/sivel/ansible-testing.git#egg=ansible_testing
+  - if [[ $PYPI_VERSION ]]; then pip install ansible==$PYPI_VERSION; fi
   - pip install flake8
   - pip install mock
   - pip install git+https://github.com/HewlettPackard/python-hpOneView.git
   - pip install coveralls
+  - |
+      if [[ $ANSIBLE == 2.1 || $ANSIBLE == 2.2 ]]; then
+        pip install git+https://github.com/sivel/ansible-testing.git#egg=ansible_testing;
+      fi
+before_script:
+  - |
+      if [[ $BRANCH ]]; then
+        git clone -b $BRANCH --single-branch https://github.com/ansible/ansible.git;
+        source ./ansible/hacking/env-setup;
+        pip install pyyaml jinja2 nose pytest passlib pycrypto six voluptuous;
+      fi
 script:
   - export ANSIBLE_LIBRARY=$PWD/library
   - export PYTHONPATH=$ANSIBLE_LIBRARY:$PYTHONPATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ env:
   - ANSIBLE=2.2 PYPI_VERSION='2.2.2.0'
   - ANSIBLE=2.3 PYPI_VERSION='2.3.0.0'
   - ANSIBLE=src-2.3 BRANCH='stable-2.3'  # source code is required to run the sanity test validate-modules
+matrix:
+  exclude:
+  - python: 3.5
+    env: ANSIBLE=2.1 PYPI_VERSION='2.1.5.0'
+  - python: 3.5
+    env: ANSIBLE=2.2 PYPI_VERSION='2.2.2.0'
 install:
   - if [[ $PYPI_VERSION ]]; then pip install ansible==$PYPI_VERSION; fi
   - pip install flake8

--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,7 @@ update_doc_fragments () {
     cp -f $docfragments $DOC_FRAGMENTS_PATH
   else
     # Find site packages. If it exists, OneView doc fragment will be copied to the discovered path
-    site_packages=$(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
+    site_packages=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
     if [ -d "${site_packages}/ansible/utils/module_docs_fragments/" ]; then
       cp -f $docfragments ${site_packages}/ansible/utils/module_docs_fragments/
     else
@@ -130,7 +130,7 @@ fi
 
 
 echo -e "\n${COLOR_START}Running tests${COLOR_END}"
-python -m unittest discover
+python -m unittest discover test/
 exit_code_tests=$?
 
 

--- a/build.sh
+++ b/build.sh
@@ -44,18 +44,18 @@ setup () {
 update_doc_fragments () {
   # NOTE: Set the destination path to copy the oneview doc fragments in an env var named DOC_FRAGMENTS_PATH.
   # Otherwise, the destination will be defined automatically.
-  docfragments="build-doc/module_docs_fragments/oneview.py"
+  local docfragments="build-doc/module_docs_fragments/oneview.py"
 
   if [ "$DOC_FRAGMENTS_PATH" ]; then
     cp -f $docfragments $DOC_FRAGMENTS_PATH
   else
     # Find site packages. If it exists, OneView doc fragment will be copied to the discovered path
-    site_packages=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+    local site_packages=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
     if [ -d "${site_packages}/ansible/utils/module_docs_fragments/" ]; then
       cp -f $docfragments ${site_packages}/ansible/utils/module_docs_fragments/
     else
       # Copy OneView doc fragments to the Ansible codebase path
-      ansible_path=$(echo $(which ansible) | sed -e 's/\/bin\/ansible//g')
+      local ansible_path=$(echo $(which ansible) | sed -e 's/\/bin\/ansible//g')
       if [ "$ansible_path" ]; then
         cp -f $docfragments ${ansible_path}/lib/ansible/utils/module_docs_fragments/
       fi
@@ -74,20 +74,25 @@ print_summary () {
 
 validate_modules () {
   if hash ansible-validate-modules 2>/dev/null; then
+    local command="ansible-validate-modules library --exclude module_utils"
+  elif [[ $ANSIBLE_HOME ]]; then
+    local command="${ANSIBLE_HOME}/test/sanity/validate-modules/validate-modules library/image_streamer_*.py library/oneview_*.py"
+  else
+    echo "WARNING: Skipping module validation. Unable to find 'ansible-validate-modules' or 'validate-modules'."
+  fi
+
+  if [[ $command ]]; then
     while read -r line
     do
       if [[ "$line" =~ "GPLv3" ]]; then
-        echo "IGNORED ERROR: GPLv3 license header not found"
+        continue
       else
         if [[ "$line" =~ "ERROR:" || "$line" =~ "IGNORE:" ]]; then
           exit_code_module_validation=1
         fi
         echo "$line"
       fi
-    done < <(ansible-validate-modules library --exclude module_utils)
-  else
-    echo "ERROR: ansible-validate-modules is not installed."
-    exit_code_module_validation=1
+    done < <($command)
   fi
 }
 


### PR DESCRIPTION
Creates the following jobs to test oneview-ansible:
1. **Python 2.7, Ansible 2.1** - Validate the modules using the legacy ansible-testing lib.
2. **Python 2.7, Ansible 2.2** - Validate the modules using the legacy ansible-testing lib.
3. **Python 2.7, Ansible 2.3** - Installed via pip. Module validation is not supported.
4. **Python 2.7, Ansible 2.3 (src)** - Installed from source code. Validates the module using the core sanity check validate-modules.
5. **Python 3.5, Ansible 2.3** - Installed via pip. Module validation is not supported.
6. **Python 3.5, Ansible 2.3 (src)** - Installed from source code. Validates the module using the core sanity check validate-modules.

Changes made in the build script:
- Fixes to run the tests against Python 3
- Uses the core validate-modules module when ansible-testing is not installed.