### PR TITLE
Removed read-only attribute in volume size extension

### DIFF
--- a/examples/oneview_volume.yml
+++ b/examples/oneview_volume.yml
@@ -42,7 +42,6 @@
         data:
           name: 'Volume with Storage Pool'
           provisionedCapacity: 2684354560  # 2.5GB - The volume actual size
-          allocatedCapacity: 3758096384  # 3.5GB - The allocated size for this volume
       delegate_to: localhost
 
     - name: Create a volume with a specified Snapshot Pool


### PR DESCRIPTION
Removes the allocatedCapacity attribute since it is a read-only attribute besides OneView accepting it but ignoring and the REST API example showing an upate with it that doesn't works.