### PR TITLE
Enclosure API500 support set_scopes

### DIFF
--- a/examples/oneview_enclosure.yml
+++ b/examples/oneview_enclosure.yml
@@ -19,6 +19,8 @@
     config: "{{ playbook_dir }}/oneview_config.json"
     enclosure_name: 0000A66101
     variant: C7000
+    scope_uris:
+      - '/rest/scopes/9dd1856d-2490-4013-92a5-c7bf89bd9f0f'
   vars_files:
     - "{{ playbook_dir }}/vars/config.yml"
   tasks:
@@ -35,6 +37,7 @@
           name: '{{ enclosure_name }}'
           licensingIntent : 'OneView'
           rackName: 'Rack-Name'
+          scopeUris: "{{ scope_uris }}"
       when: variant == 'C7000'
       delegate_to: localhost
 

--- a/oneview-ansible.md
+++ b/oneview-ansible.md
@@ -2090,6 +2090,16 @@ Manage OneView Enclosure resources.
       name: 'Test-Enclosure'
       supportDataCollectionState: 'PendingCollection'
 
+- name: Ensure that the Enclosure is present and is inserted in the desired scopes
+  oneview_enclosure:
+    config: "{{ config_file_path }}"
+    state: present
+    data:
+      name: 'Test-Enclosure'
+      scopeUris:
+        - '/rest/scopes/00SC123456'
+        - '/rest/scopes/01SC123456'
+
 ```
 
 


### PR DESCRIPTION
### Description
Add field to set scope_uris on present state. This had been missed in a previous PR.

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass. (`$ ./build.sh`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
