### PR TITLE
Added fix for network query param in storage resources for API500

### DIFF
--- a/library/oneview_storage_pool_facts.py
+++ b/library/oneview_storage_pool_facts.py
@@ -120,10 +120,14 @@ class StoragePoolFactsModule(OneViewModuleBase):
 
     def execute_module(self):
         facts = {}
+        networks = self.facts_params.pop('networks', None)
         if self.module.params.get('name'):
             storage_pool = self.oneview_client.storage_pools.get_by('name', self.module.params['name'])
         else:
             storage_pool = self.oneview_client.storage_pools.get_all(**self.facts_params)
+
+        if networks:
+            self.facts_params['networks'] = networks
 
         facts['storage_pools'] = storage_pool
         self.__get_options(facts)

--- a/library/oneview_volume_facts.py
+++ b/library/oneview_volume_facts.py
@@ -135,12 +135,15 @@ class VolumeFactsModule(OneViewModuleBase):
 
     def execute_module(self):
         ansible_facts = {}
-
+        networks = self.facts_params.pop('networks', None)
         if self.module.params.get('name'):
             ansible_facts['storage_volumes'] = self.resource_client.get_by('name', self.module.params['name'])
             ansible_facts.update(self.__gather_facts_about_one_volume(ansible_facts['storage_volumes']))
         else:
             ansible_facts['storage_volumes'] = self.resource_client.get_all(**self.facts_params)
+
+        if networks:
+            self.facts_params['networks'] = networks
 
         ansible_facts.update(self.__gather_facts_from_appliance())
 

--- a/oneview-ansible.md
+++ b/oneview-ansible.md
@@ -8730,7 +8730,7 @@ Retrieve facts about Storage Volume Templates of the OneView.
 | ------------- |-------------| ---------|----------- |--------- |
 | config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Storage Volume Template name.  |
-| options  |   No  |  | |  Retrieve additional facts. Options available: `connectableVolumeTemplates`.  |
+| options  |   No  |  | |  Retrieve additional facts. Options available: `connectableVolumeTemplates`, `reachableVolumeTemplates`, `compatibleSystems`  |
 | params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
@@ -8776,6 +8776,21 @@ Retrieve facts about Storage Volume Templates of the OneView.
 - debug: var=storage_volume_templates
 - debug: var=connectable_volume_templates
 
+- name: Gather facts about the reachable Storage Volume Templates
+  oneview_storage_volume_template_facts:
+    config: "{{ config }}"
+    options:
+      - reachableVolumeTemplates
+  delegate_to: localhost
+
+- name: Gather facts about Storage Systems compatible to the SVT
+  oneview_storage_volume_template_facts:
+    config: "{{ config }}"
+    name: "{{ volume_template_name }}"
+    options:
+      - compatibleSystems
+  delegate_to: localhost
+
 ```
 
 
@@ -8784,7 +8799,9 @@ Retrieve facts about Storage Volume Templates of the OneView.
 
 | Name          | Description  | Returned | Type       |
 | ------------- |-------------| ---------|----------- |
-| connectable_volume_templates   | Has facts about the Connectable Storage Volume Templates. |  When requested, but can be null. |  complex |
+| compatible_systems   | Has facts about Storage Systems compatible to the Storage Volume template. API version 500+ only. |  When requested, but can be null. |  complex |
+| connectable_volume_templates   | Has facts about the Connectable Storage Volume Templates. API version <= 300  only. |  When requested, but can be null. |  complex |
+| reachable_volume_templates   | Has facts about the Reachable Storage Volume Templates. API version 500+ only. |  When requested, but can be null. |  complex |
 | storage_volume_templates   | Has all the OneView facts about the Storage Volume Templates. |  Always, but can be null. |  complex |
 
 

--- a/test/test_oneview_storage_pool_facts.py
+++ b/test/test_oneview_storage_pool_facts.py
@@ -35,7 +35,10 @@ PARAMS_GET_BY_NAME = dict(
 PARAMS_GET_REACHABLE_STORAGE_POOLS = dict(
     config='config.json',
     name="Test Storage Pools",
-    options=["reachableStoragePools"]
+    options=["reachableStoragePools"],
+    params={
+        'networks': ['rest/fake/network']
+    }
 )
 
 

--- a/test/test_oneview_volume_facts.py
+++ b/test/test_oneview_volume_facts.py
@@ -33,7 +33,10 @@ PARAMS_GET_ALL_WITH_OPTIONS = dict(
     name=None,
     options=[
         'attachableVolumes', 'extraManagedVolumePaths'
-    ]
+    ],
+    params={
+        'networks': ['rest/fake/network']
+    }
 )
 
 PARAMS_GET_BY_NAME = dict(


### PR DESCRIPTION
### Description
Removes 'network' querry param from get_all() in the Storage resources.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass. (`$ ./build.sh`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
