### PR TITLE
Server Profile - Only reboot on operations that require powering off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.0.1
+#### Bug fixes & Enhancements
+- [#282](https://github.com/HewlettPackard/oneview-ansible/issues/282) Updating a Server Profile causes Server Hardware reboots for operations which do not require it
 
 # v4.0.0
 #### Notes

--- a/library/oneview_server_profile.py
+++ b/library/oneview_server_profile.py
@@ -175,7 +175,6 @@ created:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
 import time
 from module_utils.oneview import (OneViewModuleBase,
                                   ServerProfileReplaceNamesByUris,
@@ -350,7 +349,7 @@ class ServerProfileModule(OneViewModuleBase):
         try:
             resource = self.oneview_client.server_profiles.update(profile_with_updates, profile_with_updates['uri'])
         except HPOneViewException as exception:
-            error_msg = '; '.join(to_native(e) for e in exception.args)
+            error_msg = '; '.join(str(e) for e in exception.args)
             power_on_msg = 'Some server profile attributes cannot be changed while the server hardware is powered on.'
             if power_on_msg in error_msg:
                 time.sleep(10)

--- a/library/oneview_server_profile.py
+++ b/library/oneview_server_profile.py
@@ -175,6 +175,7 @@ created:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 import time
 from module_utils.oneview import (OneViewModuleBase,
                                   ServerProfileReplaceNamesByUris,
@@ -288,7 +289,7 @@ class ServerProfileModule(OneViewModuleBase):
             self.__validations_for_os_custom_attributes(data, merged_data, resource)
 
             if not ResourceComparator.compare(resource, merged_data):
-                resource = self.__update_server_profile(merged_data)
+                resource = self.__update_server_profile(merged_data, resource)
                 changed = True
                 msg = self.MSG_UPDATED
             else:
@@ -334,19 +335,36 @@ class ServerProfileModule(OneViewModuleBase):
                 matches.append(position)
         return matches
 
-    def __update_server_profile(self, profile_with_updates):
+    def __update_server_profile(self, profile_with_updates, original_profile):
         logger.debug(msg="Updating Server Profile")
 
-        if profile_with_updates.get('serverHardwareUri'):
-            logger.debug("Power off the server hardware before update")
-            self.__set_server_hardware_power_state(profile_with_updates['serverHardwareUri'], 'Off')
+        # These removes are necessary in case SH associated to the SP is being changed
+        if self.data.get('enclosureUri') is None:
+            profile_with_updates.pop('enclosureUri', None)
+        if self.data.get('enclosureBay') is None:
+            profile_with_updates.pop('enclosureBay', None)
 
-        resource = self.oneview_client.server_profiles.update(profile_with_updates, profile_with_updates['uri'])
+        # Some specific SP operations require the SH to be powered off. This method attempts
+        # the update, and in case of failure mentioning powering off the SH, a Power off on
+        # the SH is attempted, followed by the update operation again and a Power On.
+        try:
+            resource = self.oneview_client.server_profiles.update(profile_with_updates, profile_with_updates['uri'])
+        except HPOneViewException as exception:
+            error_msg = '; '.join(to_native(e) for e in exception.args)
+            power_on_msg = 'Some server profile attributes cannot be changed while the server hardware is powered on.'
+            if power_on_msg in error_msg:
+                time.sleep(10)
+                logger.debug("Update failed due to powered on Server Hardware. Powering off before retrying.")
+                self.__set_server_hardware_power_state(original_profile['serverHardwareUri'], 'Off')
 
-        if profile_with_updates.get('serverHardwareUri'):
-            logger.debug("Power on the server hardware after update")
-            self.__set_server_hardware_power_state(profile_with_updates['serverHardwareUri'], 'On')
+                logger.debug("Retrying update operation after server power off")
+                resource = self.oneview_client.server_profiles.update(profile_with_updates,
+                                                                      profile_with_updates['uri'])
 
+                logger.debug("Powering on the server hardware after update")
+                self.__set_server_hardware_power_state(profile_with_updates['serverHardwareUri'], 'On')
+            else:
+                raise HPOneViewException(error_msg)
         return resource
 
     def __create_profile(self, data, server_profile_template):

--- a/oneview-ansible.md
+++ b/oneview-ansible.md
@@ -35,6 +35,7 @@
   * [oneview_event_facts - Retrieve the facts about one or more of the OneView Events.](#oneview_event_facts)
   * [oneview_fabric - Manage OneView Fabric resources.](#oneview_fabric)
   * [oneview_fabric_facts - Retrieve the facts about one or more of the OneView Fabrics.](#oneview_fabric_facts)
+  * [oneview_fc_network_facts - Retrieve the facts about one or more of the OneView Fibre Channel Networks.](#oneview_fc_network_facts)
   * [oneview_fc_network - Manage OneView Fibre Channel Network resources.](#oneview_fc_network)
   * [oneview_fc_network_facts - Retrieve the facts about one or more of the OneView Fibre Channel Networks.](#oneview_fc_network_facts)
   * [oneview_fcoe_network - Manage OneView FCoE Network resources.](#oneview_fcoe_network)
@@ -2839,6 +2840,75 @@ Retrieve the facts about one or more of the OneView Fabrics.
 | ------------- |-------------| ---------|----------- |
 | fabric_reserved_vlan_range   | Has all the OneView facts about the reserved VLAN range |  When requested, but can be null. |  complex |
 | fabrics   | Has all the OneView facts about the Fabrics. |  Always, but can be null. |  complex |
+
+
+#### Notes
+
+- A sample configuration file for the config parameter can be found at: https://github.com/HewlettPackard/oneview-ansible/blob/master/examples/oneview_config-rename.json
+
+- Check how to use environment variables for configuration at: https://github.com/HewlettPackard/oneview-ansible#environment-variables
+
+- Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
+
+
+---
+
+
+## oneview_fc_network_facts
+Retrieve the facts about one or more of the OneView Fibre Channel Networks.
+
+#### Synopsis
+ Retrieve the facts about one or more of the Fibre Channel Networks from OneView.
+
+#### Requirements (on the host that executes the module)
+  * python >= 2.7.9
+  * hpOneView >= 2.0.1
+
+#### Options
+
+| Parameter     | Required    | Default  | Choices    | Comments |
+| ------------- |-------------| ---------|----------- |--------- |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
+| name  |   No  |  | |  Fibre Channel Network name.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
+
+
+ 
+#### Examples
+
+```yaml
+- name: Gather facts about all Fibre Channel Networks
+  oneview_fc_network_facts:
+    config: "{{ config_file_path }}"
+
+- debug: var=fc_networks
+
+- name: Gather paginated, filtered and sorted facts about Fibre Channel Networks
+  oneview_fc_network_facts:
+    config: "{{ config }}"
+    params:
+      start: 1
+      count: 3
+      sort: 'name:descending'
+      filter: 'fabricType=FabricAttach'
+- debug: var=fc_networks
+
+- name: Gather facts about a Fibre Channel Network by name
+  oneview_fc_network_facts:
+    config: "{{ config_file_path }}"
+    name: network name
+
+- debug: var=fc_networks
+
+```
+
+
+
+#### Return Values
+
+| Name          | Description  | Returned | Type       |
+| ------------- |-------------| ---------|----------- |
+| fc_networks   | Has all the OneView facts about the Fibre Channel Networks. |  Always, but can be null. |  complex |
 
 
 #### Notes

--- a/oneview-ansible.md
+++ b/oneview-ansible.md
@@ -35,7 +35,6 @@
   * [oneview_event_facts - Retrieve the facts about one or more of the OneView Events.](#oneview_event_facts)
   * [oneview_fabric - Manage OneView Fabric resources.](#oneview_fabric)
   * [oneview_fabric_facts - Retrieve the facts about one or more of the OneView Fabrics.](#oneview_fabric_facts)
-  * [oneview_fc_network_facts - Retrieve the facts about one or more of the OneView Fibre Channel Networks.](#oneview_fc_network_facts)
   * [oneview_fc_network - Manage OneView Fibre Channel Network resources.](#oneview_fc_network)
   * [oneview_fc_network_facts - Retrieve the facts about one or more of the OneView Fibre Channel Networks.](#oneview_fc_network_facts)
   * [oneview_fcoe_network - Manage OneView FCoE Network resources.](#oneview_fcoe_network)
@@ -2840,75 +2839,6 @@ Retrieve the facts about one or more of the OneView Fabrics.
 | ------------- |-------------| ---------|----------- |
 | fabric_reserved_vlan_range   | Has all the OneView facts about the reserved VLAN range |  When requested, but can be null. |  complex |
 | fabrics   | Has all the OneView facts about the Fabrics. |  Always, but can be null. |  complex |
-
-
-#### Notes
-
-- A sample configuration file for the config parameter can be found at: https://github.com/HewlettPackard/oneview-ansible/blob/master/examples/oneview_config-rename.json
-
-- Check how to use environment variables for configuration at: https://github.com/HewlettPackard/oneview-ansible#environment-variables
-
-- Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
-
-
----
-
-
-## oneview_fc_network_facts
-Retrieve the facts about one or more of the OneView Fibre Channel Networks.
-
-#### Synopsis
- Retrieve the facts about one or more of the Fibre Channel Networks from OneView.
-
-#### Requirements (on the host that executes the module)
-  * python >= 2.7.9
-  * hpOneView >= 2.0.1
-
-#### Options
-
-| Parameter     | Required    | Default  | Choices    | Comments |
-| ------------- |-------------| ---------|----------- |--------- |
-| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
-| name  |   No  |  | |  Fibre Channel Network name.  |
-| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
-
-
- 
-#### Examples
-
-```yaml
-- name: Gather facts about all Fibre Channel Networks
-  oneview_fc_network_facts:
-    config: "{{ config_file_path }}"
-
-- debug: var=fc_networks
-
-- name: Gather paginated, filtered and sorted facts about Fibre Channel Networks
-  oneview_fc_network_facts:
-    config: "{{ config }}"
-    params:
-      start: 1
-      count: 3
-      sort: 'name:descending'
-      filter: 'fabricType=FabricAttach'
-- debug: var=fc_networks
-
-- name: Gather facts about a Fibre Channel Network by name
-  oneview_fc_network_facts:
-    config: "{{ config_file_path }}"
-    name: network name
-
-- debug: var=fc_networks
-
-```
-
-
-
-#### Return Values
-
-| Name          | Description  | Returned | Type       |
-| ------------- |-------------| ---------|----------- |
-| fc_networks   | Has all the OneView facts about the Fibre Channel Networks. |  Always, but can be null. |  complex |
 
 
 #### Notes


### PR DESCRIPTION
### Description
Adding syntax to allow rebooting only when an error regarding powering off the server hardware is hit

### Issues Resolved
#282 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass. (`$ ./build.sh`).
- [X] New functionality has been documented in the CHANGELOG.
