### PR TITLE
Allow credentials to be passed in as parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v4.0.1
 #### Bug fixes & Enhancements
+- [#172](https://github.com/HewlettPackard/oneview-ansible/issues/172) Allow credentials to be defined inside the playbooks
 - [#282](https://github.com/HewlettPackard/oneview-ansible/issues/282) Updating a Server Profile causes Server Hardware reboots for operations which do not require it
 
 # v4.0.0

--- a/README.md
+++ b/README.md
@@ -149,7 +149,32 @@ In this case, you shouldn't provide the `config` argument. For example:
 
 Once you have defined the environment variables, you can run the plays.
 
-### 4. ### Setting your OneView version
+#### Parameters in the playbook
+
+The third way to pass in your HPE OneView credentials to your tasks is through explicit specification on the task.
+
+This option allows the parameters `hostname`, `username`, `password`, `api_version` and `image_streamer_hostname` to be passed directly inside your task.
+
+```yaml
+- name: Create a Fibre Channel Network
+  oneview_fc_network:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+    state: present
+    data:
+      name: "{{ network_name }}"
+      fabricType: 'FabricAttach'
+      linkStabilityTime: '30'
+      autoLoginRedistribution: true
+  no_log: true
+  delegate_to: localhost
+```
+
+Setting `no_log: true` is highly recommended in this case, as the credentials are otherwise returned in the log after task completion.
+
+### 4. Setting your OneView version
 
 The Ansible modules for HPE OneView support the API endpoints for HPE OneView 2.0, 3.0 and 3.10.
 

--- a/build.sh
+++ b/build.sh
@@ -111,7 +111,7 @@ exit_code_playbook_validation=$?
 
 echo -e "\n${COLOR_START}Running flake8${COLOR_END}"
 if hash flake8 2>/dev/null; then
-  flake8 library test --max-line-length=120 --ignore=F401,E402,F403,F405
+  flake8 library test --max-line-length=160 --ignore=F401,E402,F403,F405
   exit_code_flake8=$?
 else
   echo "ERROR:flake8 is not installed."

--- a/examples/oneview_storage_system_facts.yml
+++ b/examples/oneview_storage_system_facts.yml
@@ -37,10 +37,10 @@
 
     - debug: var=storage_systems
 
-    - name: Gather facts about a Storage System by IP (ip_hostname)
+    - name: Gather facts about a Storage System by IP (storage_hostname)
       oneview_storage_system_facts:
         config: "{{ config }}"
-        ip_hostname: "{{ storage_system_ip }}"
+        storage_hostname: "{{ storage_system_ip }}"
       delegate_to: localhost
 
     - debug: var=storage_systems
@@ -48,7 +48,7 @@
     - name: Gather facts about a Storage System by IP (hostname)
       oneview_storage_system_facts:
         config: "{{ config }}"
-        hostname: "{{ storage_system_ip }}"
+        storage_hostname: "{{ storage_system_ip }}"
       delegate_to: localhost
 
     - debug: var=storage_systems
@@ -83,7 +83,7 @@
     - name: Gather queried facts about Storage System reachable ports
       oneview_storage_system_facts:
         config: "{{ config }}"
-        hostname: "{{ storage_system_ip }}"
+        storage_hostname: "{{ storage_system_ip }}"
         options:
             - reachablePorts
         params:
@@ -97,7 +97,7 @@
     - name: Gather facts about the Storage System storage templates
       oneview_storage_system_facts:
         config: "{{ config }}"
-        hostname: "{{ storage_system_ip }}"
+        storage_hostname: "{{ storage_system_ip }}"
         options:
           - templates
         params:

--- a/library/oneview_storage_system_facts.py
+++ b/library/oneview_storage_system_facts.py
@@ -179,8 +179,7 @@ class StorageSystemFactsModule(OneViewModuleBase):
     def __init__(self):
         argument_spec = dict(
             name=dict(required=False, type='str'),
-            ip_hostname=dict(required=False, type='str'),
-            hostname=dict(required=False, type='str'),
+            storage_hostname=dict(required=False, type='str'),
             options=dict(required=False, type='list'),
             params=dict(required=False, type='dict'),
         )
@@ -197,10 +196,8 @@ class StorageSystemFactsModule(OneViewModuleBase):
         else:
             get_method = self.oneview_client.storage_systems.get_by_ip_hostname
 
-        if self.module.params.get('ip_hostname'):
-            storage_systems = get_method(self.module.params['ip_hostname'])
-        elif self.module.params.get('hostname'):
-            storage_systems = get_method(self.module.params['hostname'])
+        if self.module.params.get('storage_hostname'):
+            storage_systems = get_method(self.module.params['storage_hostname'])
         elif self.module.params.get('name'):
             storage_systems = self.oneview_client.storage_systems.get_by_name(self.module.params['name'])
         else:

--- a/library/oneview_storage_system_facts.py
+++ b/library/oneview_storage_system_facts.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 ###
 # Copyright (2016-2017) Hewlett Packard Enterprise Development LP
 #
@@ -16,34 +15,28 @@
 # limitations under the License.
 ###
 
-ANSIBLE_METADATA = {'status': ['stableinterface'],
-                    'supported_by': 'curated',
-                    'metadata_version': '1.0'}
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
 module: oneview_storage_system_facts
-short_description: Retrieve facts about the OneView Storage Systems.
+short_description: Retrieve facts about the OneView Storage Systems
 description:
     - Retrieve facts about the Storage Systems from OneView.
-version_added: "2.3"
+version_added: "2.5"
 requirements:
     - "python >= 2.7.9"
     - "hpOneView >= 4.0.0"
 author: "Gustavo Hennig (@GustavoHennig)"
 options:
-    ip_hostname:
+    storage_hostname:
       description:
         - Storage System IP or hostname.
-      required: false
-    hostname:
-      description:
-        - Storage System IP or hostname.
-      required: false
     name:
       description:
         - Storage System name.
-      required: false
     options:
       description:
         - "List with options to gather additional facts about a Storage System and related resources.
@@ -55,7 +48,6 @@ options:
           C(templates) gets a list of storage templates belonging to the storage system."
         - "To gather facts about C(storagePools), C(reachablePorts), and C(templates) it is required to inform
             either the argument C(name), C(ip_hostname), or C(hostname). Otherwise, this option will be ignored."
-      required: false
 extends_documentation_fragment:
     - oneview
     - oneview.factsparams
@@ -148,27 +140,27 @@ RETURN = '''
 storage_systems:
     description: Has all the OneView facts about the Storage Systems.
     returned: Always, but can be null.
-    type: complex
+    type: dict
 
 storage_system_host_types:
     description: Has all the OneView facts about the supported host types.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 storage_system_pools:
     description: Has all the OneView facts about the Storage Systems - Storage Pools.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 storage_system_reachable_ports:
     description: Has all the OneView facts about the Storage Systems reachable ports.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 storage_system_templates:
     description: Has all the OneView facts about the Storage Systems - Storage Templates.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -178,10 +170,10 @@ from module_utils.oneview import OneViewModuleBase
 class StorageSystemFactsModule(OneViewModuleBase):
     def __init__(self):
         argument_spec = dict(
-            name=dict(required=False, type='str'),
-            storage_hostname=dict(required=False, type='str'),
-            options=dict(required=False, type='list'),
-            params=dict(required=False, type='dict'),
+            name=dict(type='str'),
+            options=dict(type='list'),
+            params=dict(type='dict'),
+            storage_hostname=dict(type='str')
         )
 
         super(StorageSystemFactsModule, self).__init__(additional_arg_spec=argument_spec)

--- a/test/test_module_utils/test_oneview.py
+++ b/test/test_module_utils/test_oneview.py
@@ -60,6 +60,14 @@ class OneViewModuleBaseSpec(unittest.TestCase):
                        'name': 'Resource Name'
                        }
 
+    EXPECTED_ARG_SPEC = {'api_version': {'type': u'int'},
+                         'config': {'type': 'path'},
+                         'hostname': {'type': 'str'},
+                         'image_streamer_hostname': {'type': 'str'},
+                         'password': {'type': 'str'},
+                         'username': {'type': 'str'},
+                         'validate_etag': {'default': True, 'required': False, 'type': 'bool'}}
+
     def setUp(self):
         # Define OneView Client Mock (FILE)
         patcher_json_file = mock.patch.object(OneViewClient, 'from_json_file')
@@ -150,9 +158,7 @@ class OneViewModuleBaseSpec(unittest.TestCase):
         self.mock_ansible_module.params['validate_etag'] = True
 
         OneViewModuleBase(validate_etag_support=True).run()
-        expected_arg_spec = {'config': {'required': False, 'type': 'str'},
-                             'validate_etag': {'default': True, 'required': False, 'type': 'bool'}}
-        self.mock_ansible_module_init.assert_called_once_with(argument_spec=expected_arg_spec,
+        self.mock_ansible_module_init.assert_called_once_with(argument_spec=self.EXPECTED_ARG_SPEC,
                                                               supports_check_mode=False)
         self.mock_ov_client.connection.enable_etag_validation.not_been_called()
         self.mock_ov_client.connection.disable_etag_validation.not_been_called()
@@ -162,9 +168,7 @@ class OneViewModuleBaseSpec(unittest.TestCase):
         self.mock_ansible_module.params['validate_etag'] = False
 
         OneViewModuleBase(validate_etag_support=True).run()
-        expected_arg_spec = {'config': {'required': False, 'type': 'str'},
-                             'validate_etag': {'default': True, 'required': False, 'type': 'bool'}}
-        self.mock_ansible_module_init.assert_called_once_with(argument_spec=expected_arg_spec,
+        self.mock_ansible_module_init.assert_called_once_with(argument_spec=self.EXPECTED_ARG_SPEC,
                                                               supports_check_mode=False)
         self.mock_ov_client.connection.enable_etag_validation.not_been_called()
         self.mock_ov_client.connection.disable_etag_validation.assert_called_once()
@@ -175,7 +179,8 @@ class OneViewModuleBaseSpec(unittest.TestCase):
 
         OneViewModuleBase(validate_etag_support=False).run()
 
-        expected_arg_spec = {'config': {'required': False, 'type': 'str'}}
+        expected_arg_spec = deepcopy(self.EXPECTED_ARG_SPEC)
+        expected_arg_spec.pop('validate_etag')
         self.mock_ansible_module_init.assert_called_once_with(argument_spec=expected_arg_spec,
                                                               supports_check_mode=False)
 
@@ -187,8 +192,9 @@ class OneViewModuleBaseSpec(unittest.TestCase):
 
         OneViewModuleBase(validate_etag_support=False, additional_arg_spec={'options': 'list'})
 
-        expected_arg_spec = {'config': {'required': False, 'type': 'str'},
-                             'options': 'list'}
+        expected_arg_spec = deepcopy(self.EXPECTED_ARG_SPEC)
+        expected_arg_spec.pop('validate_etag')
+        expected_arg_spec['options'] = 'list'
 
         self.mock_ansible_module_init.assert_called_once_with(argument_spec=expected_arg_spec,
                                                               supports_check_mode=False)

--- a/test/test_module_utils/test_oneview.py
+++ b/test/test_module_utils/test_oneview.py
@@ -144,6 +144,25 @@ class OneViewModuleBaseSpec(unittest.TestCase):
         self.mock_ov_client_from_env_vars.assert_called_once()
         self.mock_ov_client_from_json_file.not_been_called()
 
+    def test_should_load_config_from_parameters(self):
+
+        self.mock_ansible_module.params = {'hostname': '172.16.1.1',
+                                           'username': 'admin',
+                                           'password': 'mypass',
+                                           'api_version': 500,
+                                           'image_streamer_hostname': '172.16.1.2'}
+
+        patcher = mock.patch('module_utils.oneview.OneViewClient', first='one', second='two')
+
+        self.addCleanup(patcher.stop)
+        self.mock_ov_client_from_credentials = patcher.start()
+
+        OneViewModuleBase()
+
+        self.mock_ov_client_from_env_vars.not_been_called()
+        self.mock_ov_client_from_json_file.not_been_called()
+        self.mock_ov_client_from_credentials.assert_called_once()
+
     def test_should_call_fail_json_when_oneview_sdk_not_installed(self):
         self.mock_ansible_module.params = {'config': 'config.json'}
 

--- a/test/test_oneview_storage_system_facts.py
+++ b/test/test_oneview_storage_system_facts.py
@@ -34,12 +34,12 @@ PARAMS_GET_BY_NAME = dict(
 
 PARAMS_GET_BY_IP_HOSTNAME = dict(
     config='config.json',
-    ip_hostname='10.0.0.0'
+    storage_hostname='10.0.0.0'
 )
 
 PARAMS_GET_BY_HOSTNAME = dict(
     config='config.json',
-    hostname='10.0.0.0'
+    storage_hostname='10.0.0.0'
 )
 
 PARAMS_GET_HOST_TYPES = dict(
@@ -49,13 +49,13 @@ PARAMS_GET_HOST_TYPES = dict(
 
 PARAMS_GET_REACHABLE_PORTS = dict(
     config='config.json',
-    hostname='10.0.0.0',
+    storage_hostname='10.0.0.0',
     options=["reachablePorts"]
 )
 
 PARAMS_GET_TEMPLATES = dict(
     config='config.json',
-    hostname='10.0.0.0',
+    storage_hostname='10.0.0.0',
     options=["templates"]
 )
 
@@ -72,7 +72,7 @@ PARAMS_GET_POOL_BY_NAME = dict(
 
 PARAMS_GET_POOL_BY_IP_HOSTNAME = dict(
     config='config.json',
-    ip_hostname='10.0.0.0',
+    storage_hostname='10.0.0.0',
     options=["storagePools"]
 )
 
@@ -109,7 +109,7 @@ class StorageSystemFactsSpec(unittest.TestCase,
 
     def test_should_get_storage_system_by_ip_hostname(self):
         self.storage_systems.get_by_ip_hostname.return_value = {"ip_hostname": "10.0.0.0"}
-        self.mock_ansible_module.params = PARAMS_GET_BY_IP_HOSTNAME
+        self.mock_ansible_module.params = PARAMS_GET_BY_HOSTNAME
 
         StorageSystemFactsModule().run()
 


### PR DESCRIPTION
### Description
Allow credentials to be passed in as parameters
- Changed double underscore convention for single underscore
- Updated create_oneview_client method to accept parameters

### Issues Resolved
Fixes #172

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass. (`$ ./build.sh`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
