### PR TITLE
Allow Server Hardwares to be unassigned in Server Profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 #### Bug fixes & Enhancements
 - [#172](https://github.com/HewlettPackard/oneview-ansible/issues/172) Allow credentials to be defined inside the playbooks
 - [#282](https://github.com/HewlettPackard/oneview-ansible/issues/282) Updating a Server Profile causes Server Hardware reboots for operations which do not require it
+- [#285](https://github.com/HewlettPackard/oneview-ansible/issues/285) Modules cannot unassign a Server Hardware or create SP with unassigned SH
 
 # v4.0.0
 #### Notes

--- a/examples/oneview_server_profile.yml
+++ b/examples/oneview_server_profile.yml
@@ -51,7 +51,7 @@
       oneview_server_profile:
         config: "{{ config }}"
         data:
-          server_template: "{{ ov_template }}"
+          serverProfileTemplateName: "{{ ov_template }}"
           name: "{{ inventory_hostname }}"
       delegate_to: localhost
       register: result
@@ -140,6 +140,17 @@
       delegate_to: localhost
 
     - debug: var=server_profile
+
+    - name: Unassign Server Hardware from Server Profile
+      oneview_server_profile:
+        config: "{{ config }}"
+        # This is required for unassigning a SH, or creating a SP and not auto-assigning a SH
+        auto_assign_server_hardware: False
+        data:
+          name: "{{ inventory_hostname }}"
+          # Specify a blank serverHardwareName or serverHardwareUri when auto_assign_server_hardware is False to unassign a SH
+          serverHardwareName:
+      delegate_to: localhost
 
     - name: Delete the Server Profile
       oneview_server_profile:

--- a/library/module_utils/oneview.py
+++ b/library/module_utils/oneview.py
@@ -62,10 +62,7 @@ class OneViewModuleBase(object):
     )
 
     ONEVIEW_VALIDATE_ETAG_ARGS = dict(
-        validate_etag=dict(
-            required=False,
-            type='bool',
-            default=True)
+        validate_etag=dict(type='bool', default=True)
     )
 
     resource_client = None

--- a/library/oneview_server_profile.py
+++ b/library/oneview_server_profile.py
@@ -389,6 +389,8 @@ class ServerProfileModule(OneViewModuleBase):
             if power_on_msg in error_msg:
                 logger.debug("Update failed due to powered on Server Hardware. Powering off before retrying.")
                 time.sleep(10)  # sleep timer to avoid timing issues after update operation failed
+
+                # When reassigning Server Hardwares, both the original and the new SH should be set to OFF
                 self.__set_server_hardware_power_state(original_profile['serverHardwareUri'], 'Off')
                 self.__set_server_hardware_power_state(profile_with_updates['serverHardwareUri'], 'Off')
 

--- a/oneview-ansible.md
+++ b/oneview-ansible.md
@@ -90,14 +90,14 @@
   * [oneview_server_hardware_facts - Retrieve facts about the OneView Server Hardwares.](#oneview_server_hardware_facts)
   * [oneview_server_hardware_type - Manage OneView Server Hardware Type resources.](#oneview_server_hardware_type)
   * [oneview_server_hardware_type_facts - Retrieve facts about Server Hardware Types of the OneView.](#oneview_server_hardware_type_facts)
-  * [oneview_server_profile - Manage OneView Server Profile resources.](#oneview_server_profile)
+  * [oneview_server_profile - Manage OneView Server Profile resources](#oneview_server_profile)
   * [oneview_server_profile_facts - Retrieve facts about the OneView Server Profiles.](#oneview_server_profile_facts)
   * [oneview_server_profile_template - Manage OneView Server Profile Template resources.](#oneview_server_profile_template)
   * [oneview_server_profile_template_facts - Retrieve facts about the Server Profile Templates from OneView.](#oneview_server_profile_template_facts)
   * [oneview_storage_pool - Manage OneView Storage Pool resources.](#oneview_storage_pool)
   * [oneview_storage_pool_facts - Retrieve facts about one or more Storage Pools.](#oneview_storage_pool_facts)
   * [oneview_storage_system - Manage OneView Storage System resources.](#oneview_storage_system)
-  * [oneview_storage_system_facts - Retrieve facts about the OneView Storage Systems.](#oneview_storage_system_facts)
+  * [oneview_storage_system_facts - Retrieve facts about the OneView Storage Systems](#oneview_storage_system_facts)
   * [oneview_storage_volume_attachment - Provides an interface to remove extra presentations from a specified server profile.](#oneview_storage_volume_attachment)
   * [oneview_storage_volume_attachment_facts - Retrieve facts about the OneView Storage Volume Attachments.](#oneview_storage_volume_attachment_facts)
   * [oneview_storage_volume_template - Manage OneView Storage Volume Template resources.](#oneview_storage_volume_template)
@@ -7611,19 +7611,19 @@ Retrieve facts about Server Hardware Types of the OneView.
 
 
 ## oneview_server_profile
-Manage OneView Server Profile resources.
+Manage OneView Server Profile resources
 
 #### Synopsis
  Manage the servers lifecycle with OneView Server Profiles. On `present` state, it selects a server hardware automatically based on the server profile configuration if no server hardware was provided.
 
 #### Requirements (on the host that executes the module)
-  * python >= 2.7.9
   * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
+| auto_assign_server_hardware  |   |  True  | <ul> <li>True</li>  <li>False</li> </ul> |  Bool indicating whether or not a Server Hardware should be automatically retrieved and assigned to the Server Profile. When set to true, creates and updates try to ensure that an available Server Hardware is assigned to the Server Profile. When set to false, if no Server Hardware is specified during creation, the profile is created as 'unassigned'. If the profile already has a Server Hardware assigned to it and a serverHardwareName or serverHardwareUri is specified as None, the Server Profile will have its Server Hardware unassigned.  |
 | config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Server Profile properties.  |
 | state  |   |  present  | <ul> <li>present</li>  <li>absent</li>  <li>compliant</li> </ul> |  Indicates the desired state for the Server Profile resource by the end of the playbook execution. `present` will ensure data properties are compliant with OneView. This operation will power off the Server Hardware before configuring the Server Profile. After it completes, the Server Hardware is powered on. `absent` will remove the resource from OneView, if it exists. `compliant` will make the server profile compliant with its server profile template, when this option was specified. If there are Offline updates, the Server Hardware is turned off before remediate compliance issues and turned on after that.  |
@@ -7636,8 +7636,8 @@ Manage OneView Server Profile resources.
 ```yaml
 - name: Create a Server Profile from a Server Profile Template with automatically selected hardware
   oneview_server_profile:
-    config: "{{ config }}"
-    state: "present"
+    config: /etc/oneview/oneview_config.json
+    state: present
     data:
         name: Web-Server-L2
         # You can choose either server_template or serverProfileTemplateUri to inform the Server Profile Template
@@ -7645,38 +7645,39 @@ Manage OneView Server Profile resources.
         server_template: Compute-node-template
         # You can inform a server_hardware or a serverHardwareUri. If any hardware was informed, it will try
         # get one available automatically
-        # server_hardware: "Encl1, bay 12"
-        # serverHardwareUri: "/rest/server-hardware/30303437-3933-4753-4831-30335835524E"
+        # server_hardware: Encl1, bay 12
+        # serverHardwareUri: /rest/server-hardware/30303437-3933-4753-4831-30335835524E
 
         # You can choose either serverHardwareTypeUri or serverHardwareTypeName to inform the Server Hardware Type
-        # serverHardwareTypeUri: '/rest/server-hardware-types/BCAB376E-DA2E-450D-B053-0A9AE7E5114C'
-        # serverHardwareTypeName: 'SY 480 Gen9 1'
+        # serverHardwareTypeUri: /rest/server-hardware-types/BCAB376E-DA2E-450D-B053-0A9AE7E5114C
+        # serverHardwareTypeName: SY 480 Gen9 1
         # You can choose either enclosureName or enclosureUri to inform the Enclosure
-        # enclosureUri: '/rest/enclosures/09SGH100Z6J1'
-        enclosureName: '0000A66102'
+        # enclosureUri: /rest/enclosures/09SGH100Z6J1
+        enclosureName: 0000A66102
         sanStorage:
-          hostOSType: 'Windows 2012 / WS2012 R2'
+          hostOSType: Windows 2012 / WS2012 R2
           manageSanStorage: true
           volumeAttachments:
             - id: 1
               # You can choose either volumeName or volumeUri to inform the Volumes
-              # volumeName: 'DemoVolume001'
-              volumeUri: '/rest/storage-volumes/BCAB376E-DA2E-450D-B053-0A9AE7E5114C'
+              # volumeName: DemoVolume001
+              volumeUri: /rest/storage-volumes/BCAB376E-DA2E-450D-B053-0A9AE7E5114C
               # You can choose either volumeStoragePoolUri or volumeStoragePoolName to inform the Volume Storage Pool
-              # volumeStoragePoolName: 'FST_CPG2'
-              volumeStoragePoolUri: '/rest/storage-pools/30303437-3933-4753-4831-30335835524E'
+              # volumeStoragePoolName: FST_CPG2
+              volumeStoragePoolUri: /rest/storage-pools/30303437-3933-4753-4831-30335835524E
               # You can choose either volumeStorageSystemUri or volumeStorageSystemName to inform the Volume Storage
               # System
-              # volumeStorageSystemName: 'ThreePAR7200-2127'
-              volumeStorageSystemUri: '/rest/storage-systems/TXQ1000307'
+              # volumeStorageSystemName: ThreePAR7200-2127
+              volumeStorageSystemUri: /rest/storage-systems/TXQ1000307
               lunType: 'Auto'
               storagePaths:
                 - isEnabled: true
                   connectionId: 1
-                  storageTargetType: 'Auto'
+                  storageTargetType: Auto
                 - isEnabled: true
                   connectionId: 2
-                  storageTargetType: 'Auto'
+                  storageTargetType: Auto
+  delegate_to: localhost
 - debug: var=server_profile
 - debug: var=serial_number
 - debug: var=server_hardware
@@ -7685,9 +7686,9 @@ Manage OneView Server Profile resources.
 
 - name: Create a Server Profile with connections
   oneview_server_profile:
-    config: "{{ config }}"
+    config: /etc/oneview/oneview_config.json
     data:
-      name: "server-profile-with-connections"
+      name: server-profile-with-connections
       connections:
         - id: 1
           name: connection1
@@ -7697,19 +7698,32 @@ Manage OneView Server Profile resources.
           networkName: eth-demo
   delegate_to: localhost
 
+- name: Unassign Server Hardware from Server Profile
+  oneview_server_profile:
+    config: /etc/oneview/oneview_config.json
+    # This is required for unassigning a SH, or creating a SP and not auto-assigning a SH
+    auto_assign_server_hardware: False
+    data:
+      name: server-profile-with-sh
+      # Specify a blank serverHardwareName or serverHardwareUri when auto_assign_server_hardware is False to unassign a SH
+      serverHardwareName:
+  delegate_to: localhost
+
 - name : Remediate compliance issues
   oneview_server_profile:
-     config: "{{ config }}"
-     state: "compliant"
-     data:
+    config: /etc/oneview/oneview_config.json
+    state: compliant
+    data:
         name: Web-Server-L2
+  delegate_to: localhost
 
 - name : Remove the server profile
   oneview_server_profile:
-    config: "{{ config }}"
-    state: "absent"
+    config: /etc/oneview/oneview_config.json
+    state: absent
     data:
         name: Web-Server-L2
+  delegate_to: localhost
 
 ```
 
@@ -7719,11 +7733,11 @@ Manage OneView Server Profile resources.
 
 | Name          | Description  | Returned | Type       |
 | ------------- |-------------| ---------|----------- |
-| compliance_preview   | Has the OneView facts about the manual and automatic updates required to make the server profile consistent with its template. |  On states 'present' and 'compliant'. |  complex |
+| compliance_preview   | Has the OneView facts about the manual and automatic updates required to make the server profile consistent with its template. |  On states 'present' and 'compliant'. |  dict |
 | created   | Indicates if the Server Profile was created. |  On states 'present' and 'compliant'. |  bool |
-| serial_number   | Has the Server Profile serial number. |  On states 'present' and 'compliant'. |  complex |
-| server_hardware   | Has the OneView facts about the Server Hardware. |  On states 'present' and 'compliant'. |  complex |
-| server_profile   | Has the OneView facts about the Server Profile. |  On states 'present' and 'compliant'. |  complex |
+| serial_number   | Has the Server Profile serial number. |  On states 'present' and 'compliant'. |  dict |
+| server_hardware   | Has the OneView facts about the Server Hardware. |  On states 'present' and 'compliant'. |  dict |
+| server_profile   | Has the OneView facts about the Server Profile. |  On states 'present' and 'compliant'. |  dict |
 
 
 #### Notes
@@ -8319,7 +8333,7 @@ Manage OneView Storage System resources.
 
 
 ## oneview_storage_system_facts
-Retrieve facts about the OneView Storage Systems.
+Retrieve facts about the OneView Storage Systems
 
 #### Synopsis
  Retrieve facts about the Storage Systems from OneView.
@@ -8333,11 +8347,10 @@ Retrieve facts about the OneView Storage Systems.
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
 | config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
-| hostname  |   No  |  | |  Storage System IP or hostname.  |
-| ip_hostname  |   No  |  | |  Storage System IP or hostname.  |
-| name  |   No  |  | |  Storage System name.  |
-| options  |   No  |  | |  List with options to gather additional facts about a Storage System and related resources. Options allowed: `hostTypes` gets the list of supported host types. `storagePools` gets a list of storage pools belonging to the specified storage system. `reachablePorts` gets a list of storage system reachable ports. Accepts `params`. An additional `networks` list param can be used to restrict the search for only these ones. `templates` gets a list of storage templates belonging to the storage system.  To gather facts about `storagePools`, `reachablePorts`, and `templates` it is required to inform either the argument `name`, `ip_hostname`, or `hostname`. Otherwise, this option will be ignored.  |
+| name  |   |  | |  Storage System name.  |
+| options  |   |  | |  List with options to gather additional facts about a Storage System and related resources. Options allowed: `hostTypes` gets the list of supported host types. `storagePools` gets a list of storage pools belonging to the specified storage system. `reachablePorts` gets a list of storage system reachable ports. Accepts `params`. An additional `networks` list param can be used to restrict the search for only these ones. `templates` gets a list of storage templates belonging to the storage system.  To gather facts about `storagePools`, `reachablePorts`, and `templates` it is required to inform either the argument `name`, `ip_hostname`, or `hostname`. Otherwise, this option will be ignored.  |
 | params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
+| storage_hostname  |   |  | |  Storage System IP or hostname.  |
 
 
  
@@ -8433,11 +8446,11 @@ Retrieve facts about the OneView Storage Systems.
 
 | Name          | Description  | Returned | Type       |
 | ------------- |-------------| ---------|----------- |
-| storage_system_host_types   | Has all the OneView facts about the supported host types. |  When requested, but can be null. |  complex |
-| storage_system_pools   | Has all the OneView facts about the Storage Systems - Storage Pools. |  When requested, but can be null. |  complex |
-| storage_system_reachable_ports   | Has all the OneView facts about the Storage Systems reachable ports. |  When requested, but can be null. |  complex |
-| storage_system_templates   | Has all the OneView facts about the Storage Systems - Storage Templates. |  When requested, but can be null. |  complex |
-| storage_systems   | Has all the OneView facts about the Storage Systems. |  Always, but can be null. |  complex |
+| storage_system_host_types   | Has all the OneView facts about the supported host types. |  When requested, but can be null. |  dict |
+| storage_system_pools   | Has all the OneView facts about the Storage Systems - Storage Pools. |  When requested, but can be null. |  dict |
+| storage_system_reachable_ports   | Has all the OneView facts about the Storage Systems reachable ports. |  When requested, but can be null. |  dict |
+| storage_system_templates   | Has all the OneView facts about the Storage Systems - Storage Templates. |  When requested, but can be null. |  dict |
+| storage_systems   | Has all the OneView facts about the Storage Systems. |  Always, but can be null. |  dict |
 
 
 #### Notes

--- a/test/test_module_utils/test_oneview.py
+++ b/test/test_module_utils/test_oneview.py
@@ -66,7 +66,7 @@ class OneViewModuleBaseSpec(unittest.TestCase):
                          'image_streamer_hostname': {'type': 'str'},
                          'password': {'type': 'str'},
                          'username': {'type': 'str'},
-                         'validate_etag': {'default': True, 'required': False, 'type': 'bool'}}
+                         'validate_etag': {'type': 'bool', 'default': True}}
 
     def setUp(self):
         # Define OneView Client Mock (FILE)

--- a/test/test_oneview_server_profile.py
+++ b/test/test_oneview_server_profile.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
 ###
 # Copyright (2016-2017) Hewlett Packard Enterprise Development LP
 #
@@ -60,12 +58,14 @@ BASIC_TEMPLATE = dict(
 
 PARAMS_FOR_PRESENT = dict(
     config='config.json',
+    auto_assign_server_hardware=True,
     state='present',
     data=BASIC_PROFILE
 )
 
 PARAMS_FOR_UPDATE = dict(
     config='config.json',
+    auto_assign_server_hardware=True,
     state='present',
     data=dict(
         name=SERVER_PROFILE_NAME,
@@ -80,6 +80,7 @@ PARAMS_FOR_UPDATE = dict(
 
 PARAMS_FOR_COMPLIANT = dict(
     config='config.json',
+    auto_assign_server_hardware=True,
     state='compliant',
     data=dict(name="Server-Template-7000")
 )
@@ -333,7 +334,7 @@ class ServerProfileModuleSpec(unittest.TestCase,
         profile_from_template = deepcopy(BASIC_PROFILE)
 
         param_for_present = deepcopy(PARAMS_FOR_PRESENT)
-        param_for_present['data']['server_template'] = 'Server-Template-7000'
+        param_for_present['data']['serverProfileTemplateName'] = 'Server-Template-7000'
 
         self.mock_ov_client.server_profiles.get_by_name.return_value = None
         self.mock_ov_client.server_profiles.create.return_value = CREATED_BASIC_PROFILE
@@ -396,7 +397,7 @@ class ServerProfileModuleSpec(unittest.TestCase,
         profile_data['serverHardwareUri'] = '/rest/server-hardware/31393736-3831-4753-567h-30335837524E'
 
         param_for_present = deepcopy(PARAMS_FOR_PRESENT)
-        param_for_present['data']['server_hardware'] = "ServerHardwareName"
+        param_for_present['data']['serverHardwareName'] = "ServerHardwareName"
 
         self.mock_ov_client.server_profiles.get_by_name.return_value = None
         self.mock_ov_client.server_profiles.create.return_value = CREATED_BASIC_PROFILE
@@ -420,8 +421,8 @@ class ServerProfileModuleSpec(unittest.TestCase,
         profile_from_template = deepcopy(BASIC_PROFILE)
 
         param_for_present = deepcopy(PARAMS_FOR_PRESENT)
-        param_for_present['data']['server_hardware'] = "ServerHardwareName"
-        param_for_present['data']['server_template'] = "TemplateA200"
+        param_for_present['data']['serverHardwareName'] = "ServerHardwareName"
+        param_for_present['data']['serverProfileTemplateName'] = "TemplateA200"
 
         self.mock_ov_client.server_profiles.get_by_name.return_value = None
         self.mock_ov_client.server_profiles.create.return_value = CREATED_BASIC_PROFILE
@@ -449,7 +450,7 @@ class ServerProfileModuleSpec(unittest.TestCase,
 
     def test_should_try_create_with_informed_hardware_25_times_when_not_exists(self):
         param_for_present = deepcopy(PARAMS_FOR_PRESENT)
-        param_for_present['data']['server_hardware'] = "ServerHardwareName"
+        param_for_present['data']['serverHardwareName'] = "ServerHardwareName"
 
         self.mock_ov_client.server_profiles.get_by_name.return_value = None
         self.mock_ov_client.server_profiles.create.side_effect = TASK_ERROR
@@ -473,7 +474,7 @@ class ServerProfileModuleSpec(unittest.TestCase,
         profile_data['serverHardwareUri'] = '/rest/server-hardware/31393736-3831-4753-567h-30335837524E'
 
         params_for_present = deepcopy(PARAMS_FOR_PRESENT)
-        params_for_present['data']['server_hardware'] = "ServerHardwareName"
+        params_for_present['data']['serverHardwareName'] = "ServerHardwareName"
 
         self.mock_ov_client.server_profiles.get_by_name.return_value = None
         self.mock_ov_client.server_profiles.create.side_effect = [TASK_ERROR, CREATED_BASIC_PROFILE]
@@ -553,8 +554,8 @@ class ServerProfileModuleSpec(unittest.TestCase,
 
     def test_fail_when_informed_template_not_exist_for_creation(self):
         params_for_present = deepcopy(PARAMS_FOR_PRESENT)
-        params_for_present['data']['server_hardware'] = "ServerHardwareName"
-        params_for_present['data']['server_template'] = "TemplateA200"
+        params_for_present['data']['serverHardwareName'] = "ServerHardwareName"
+        params_for_present['data']['serverProfileTemplateName'] = "TemplateA200"
 
         self.mock_ov_client.server_profiles.get_by_name.return_value = None
         self.mock_ov_client.server_hardware.get_by.return_value = [FAKE_SERVER_HARDWARE]
@@ -568,8 +569,8 @@ class ServerProfileModuleSpec(unittest.TestCase,
 
     def test_fail_when_informed_hardware_not_exist_for_creation(self):
         params_for_present = deepcopy(PARAMS_FOR_PRESENT)
-        params_for_present['data']['server_hardware'] = "ServerHardwareName"
-        params_for_present['data']['server_template'] = "TemplateA200"
+        params_for_present['data']['serverHardwareName'] = "ServerHardwareName"
+        params_for_present['data']['serverProfileTemplateName'] = "TemplateA200"
 
         self.mock_ov_client.server_profiles.get_by_name.return_value = None
         self.mock_ov_client.server_hardware.get_by.return_value = None
@@ -1393,9 +1394,10 @@ class ServerProfileModuleSpec(unittest.TestCase,
     @mock.patch.object(ResourceComparator, 'compare')
     def test_should_update_when_data_changed(self, mock_resource_compare):
         profile_data = deepcopy(BASIC_PROFILE)
+        profile_data['serverHardwareUri'] = None
         mock_resource_compare.return_value = False
 
-        self.mock_ov_client.server_profiles.get_by_name.return_value = profile_data
+        self.mock_ov_client.server_profiles.get_by_name.return_value = deepcopy(BASIC_PROFILE)
         self.mock_ov_client.server_profiles.update.return_value = CREATED_BASIC_PROFILE
         self.mock_ov_client.server_hardware.update_power_state.return_value = {}
         self.mock_ansible_module.params = deepcopy(PARAMS_FOR_PRESENT)
@@ -1498,8 +1500,8 @@ class ServerProfileModuleSpec(unittest.TestCase,
         profile_data = deepcopy(CREATED_BASIC_PROFILE)
 
         params_for_present = deepcopy(PARAMS_FOR_PRESENT)
-        params_for_present['data']['server_hardware'] = "ServerHardwareName"
-        params_for_present['data']['server_template'] = "TemplateA200"
+        params_for_present['data']['serverHardwareName'] = "ServerHardwareName"
+        params_for_present['data']['serverProfileTemplateName'] = "TemplateA200"
 
         mock_resource_compare.return_value = False
 
@@ -1519,8 +1521,8 @@ class ServerProfileModuleSpec(unittest.TestCase,
         profile_data = deepcopy(CREATED_BASIC_PROFILE)
 
         params_for_present = deepcopy(PARAMS_FOR_PRESENT)
-        params_for_present['data']['server_hardware'] = "ServerHardwareName"
-        params_for_present['data']['server_template'] = "TemplateA200"
+        params_for_present['data']['serverHardwareName'] = "ServerHardwareName"
+        params_for_present['data']['serverProfileTemplateName'] = "TemplateA200"
 
         mock_resource_compare.return_value = False
 
@@ -1539,6 +1541,7 @@ class ServerProfileModuleSpec(unittest.TestCase,
     @mock.patch.object(ServerProfileMerger, 'merge_data')
     def test_should_call_deep_merge_when_resource_found(self, mock_deep_merge, mock_resource_compare):
         server_profile = deepcopy(BASIC_PROFILE)
+        server_profile['serverHardwareUri'] = None
         self.mock_ov_client.server_profiles.get_by_name.return_value = server_profile
         self.mock_ov_client.server_profiles.update.return_value = CREATED_BASIC_PROFILE
         self.mock_ov_client.server_hardware.update_power_state.return_value = {}
@@ -1546,7 +1549,7 @@ class ServerProfileModuleSpec(unittest.TestCase,
 
         ServerProfileModule().run()
 
-        mock_deep_merge.assert_called_once_with(server_profile, PARAMS_FOR_PRESENT['data'])
+        mock_deep_merge.assert_called_once_with(server_profile, server_profile)
 
     @mock.patch.object(ResourceComparator, 'compare')
     @mock.patch.object(ServerProfileMerger, 'merge_data')
@@ -1871,6 +1874,36 @@ class ServerProfileModuleSpec(unittest.TestCase,
         self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             msg=ServerProfileModule.MSG_ALREADY_PRESENT,
+            ansible_facts=mock_facts
+        )
+
+    # @mock.patch.object(ResourceComparator, 'compare')
+    def test_should_unassign_server_hardware(self):
+        sp_without_sh = deepcopy(CREATED_BASIC_PROFILE)
+        sp_without_sh['serverHardwareUri'] = None
+
+        params_for_unassign = deepcopy(PARAMS_FOR_PRESENT)
+        params_for_unassign['auto_assign_server_hardware'] = False
+        params_for_unassign['data'] = deepcopy(sp_without_sh)
+
+        # mock_resource_compare.return_value = False
+
+        self.mock_ov_client.server_profiles.get_by_name.return_value = deepcopy(CREATED_BASIC_PROFILE)
+        self.mock_ov_client.server_profiles.update.return_value = sp_without_sh
+        self.mock_ov_client.server_hardware.update_power_state.return_value = {}
+        self.mock_ansible_module.params = deepcopy(params_for_unassign)
+
+        mock_facts = deepcopy(gather_facts(self.mock_ov_client))
+        mock_facts['server_profile']['serverHardwareUri'] = None
+        mock_facts['server_hardware'] = None
+
+        ServerProfileModule().run()
+
+        self.mock_ov_client.server_profiles.update.assert_called_once_with(sp_without_sh, sp_without_sh['uri'])
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=ServerProfileModule.MSG_UPDATED,
             ansible_facts=mock_facts
         )
 

--- a/test/test_oneview_server_profile.py
+++ b/test/test_oneview_server_profile.py
@@ -1877,7 +1877,6 @@ class ServerProfileModuleSpec(unittest.TestCase,
             ansible_facts=mock_facts
         )
 
-    # @mock.patch.object(ResourceComparator, 'compare')
     def test_should_unassign_server_hardware(self):
         sp_without_sh = deepcopy(CREATED_BASIC_PROFILE)
         sp_without_sh['serverHardwareUri'] = None
@@ -1885,8 +1884,6 @@ class ServerProfileModuleSpec(unittest.TestCase,
         params_for_unassign = deepcopy(PARAMS_FOR_PRESENT)
         params_for_unassign['auto_assign_server_hardware'] = False
         params_for_unassign['data'] = deepcopy(sp_without_sh)
-
-        # mock_resource_compare.return_value = False
 
         self.mock_ov_client.server_profiles.get_by_name.return_value = deepcopy(CREATED_BASIC_PROFILE)
         self.mock_ov_client.server_profiles.update.return_value = sp_without_sh


### PR DESCRIPTION
### Description
Added auto_assign_server_hardware param to ov server profiles
- Allows for creation of SP with unassigned SH
- Allows for unassigning a SH from a SP
- Updates unit tests
- Adds documentation for new param

### Issues Resolved
#285

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass. (`$ ./build.sh`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
