### PR TITLE
Add uri parameter to SP facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [#282](https://github.com/HewlettPackard/oneview-ansible/issues/282) Updating a Server Profile causes Server Hardware reboots for operations which do not require it
 - [#285](https://github.com/HewlettPackard/oneview-ansible/issues/285) Modules cannot unassign a Server Hardware or create SP with unassigned SH
 - [#288](https://github.com/HewlettPackard/oneview-ansible/issues/288) Adding osCustomAttributes to a SP which had none before results in failure
+- [#290](https://github.com/HewlettPackard/oneview-ansible/issues/290) Issue with filter on oneview_server_profile_facts
 
 # v4.0.0
 #### Notes

--- a/examples/oneview_server_profile_facts.yml
+++ b/examples/oneview_server_profile_facts.yml
@@ -56,6 +56,13 @@
 
     - debug: var=server_profiles
 
+    - name: Gather facts about a Server Profile by uri
+      oneview_server_profile_facts:
+        config: "{{ config }}"
+        uri: "{{server_profiles[0]['uri']}}"
+      delegate_to: localhost
+
+    - debug: var=server_profiles
 
     - name: Gather facts about available servers and bays for a given enclosure group and server hardware type
       oneview_server_profile_facts:

--- a/examples/oneview_server_profile_template_facts.yml
+++ b/examples/oneview_server_profile_template_facts.yml
@@ -48,6 +48,12 @@
 
     - debug: var=server_profile_templates
 
+    - name: Gather facts about a Server Profile Template by URI
+      oneview_server_profile_template_facts:
+        config: "{{ config }}"
+        uri: "{{server_profile_templates[0]['uri']}}"
+      delegate_to: localhost
+
     - name: Gather facts about a template and a profile with the configuration based on this template
       oneview_server_profile_template_facts:
         config: "{{ config }}"

--- a/library/oneview_server_profile_facts.py
+++ b/library/oneview_server_profile_facts.py
@@ -35,7 +35,9 @@ options:
     name:
       description:
         - Server Profile name.
-      required: false
+    uri:
+      description:
+        - Server Profile uri.
     options:
       description:
         - "List with options to gather additional facts about Server Profile related resources.
@@ -44,7 +46,6 @@ options:
           C(available_targets), C(newProfileTemplate),"
         - "To gather facts about C(compliancePreview), C(messages), C(newProfileTemplate) and C(transformation)
            a Server Profile name is required. Otherwise, these options will be ignored."
-      required: false
 
 extends_documentation_fragment:
     - oneview
@@ -75,11 +76,19 @@ EXAMPLES = '''
 - name: Gather facts about a Server Profile by name
   oneview_server_profile_facts:
     config: "{{ config }}"
-    name: "WebServer-1"
+    name: WebServer-1
   delegate_to: localhost
 
 - debug: var=server_profiles
 
+
+- name: Gather facts about a Server Profile by uri
+  oneview_server_profile_facts:
+    config: "{{ config }}"
+    uri: /rest/server-profiles/e23d9fa4-f926-4447-b971-90116ca3e61e
+  delegate_to: localhost
+
+- debug: var=server_profiles
 
 - name: Gather facts about available servers and bays for a given enclosure group and server hardware type
   oneview_server_profile_facts:
@@ -141,75 +150,75 @@ RETURN = '''
 server_profiles:
     description: Has all the OneView facts about the Server Profiles.
     returned: Always, but can be null.
-    type: complex
+    type: dict
 
 server_profile_schema:
     description: Has the facts about the Server Profile schema.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 server_profile_compliance_preview:
     description:
         Has all the facts about the manual and automatic updates required to make the server profile compliant
         with its template.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 server_profile_new_profile_template:
     description:
         Has the facts derived from a server profile, which can be used to generate a server profile template.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 server_profile_profile_ports:
     description: Has the facts about the port model associated with the profile.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 server_profile_messages:
     description: Has the facts about the profile status messages associated with the profile.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 server_profile_transformation:
     description:
         Has the facts about the transformation of an existing profile by supplying a new server hardware type
         and/or enclosure group.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 server_profile_available_networks:
     description:
         Has all the facts about the list of Ethernet networks, Fibre Channel networks and network sets that
         are available to the server profile along with their respective ports.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 server_profile_available_servers:
     description: Has the facts about the list of available servers.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 server_profile_available_storage_system:
     description:
         Has the facts about a specific storage system and its associated volumes that are available to
         the server profile.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 server_profile_available_storage_systems:
     description:
         Has the facts about the list of the storage systems and their associated volumes that are available to
         the server profile.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 
 server_profile_available_targets:
     description:
         Has the facts about the target servers and empty device bays that are available for assignment to
         the server profile.
     returned: When requested, but can be null.
-    type: complex
+    type: dict
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/library/oneview_server_profile_facts.py
+++ b/library/oneview_server_profile_facts.py
@@ -218,9 +218,10 @@ from module_utils.oneview import OneViewModuleBase
 
 class ServerProfileFactsModule(OneViewModuleBase):
     argument_spec = dict(
-        name=dict(required=False, type='str'),
-        options=dict(required=False, type='list'),
-        params=dict(required=False, type='dict')
+        name=dict(type='str'),
+        uri=dict(type='str'),
+        options=dict(type='list'),
+        params=dict(type='dict')
     )
 
     def __init__(self):
@@ -235,6 +236,12 @@ class ServerProfileFactsModule(OneViewModuleBase):
             server_profiles = self.oneview_client.server_profiles.get_by("name", self.module.params['name'])
             if len(server_profiles) > 0:
                 server_profile_uri = server_profiles[0]['uri']
+        elif self.module.params.get('uri'):
+            server_profiles = []
+            server_profile = self.oneview_client.server_profiles.get(self.module.params['uri'])
+            if server_profile:
+                server_profile_uri = server_profile['uri']
+                server_profiles.append(server_profile)
         else:
             server_profiles = self.oneview_client.server_profiles.get_all(**self.facts_params)
 

--- a/library/oneview_storage_volume_template.py
+++ b/library/oneview_storage_volume_template.py
@@ -90,7 +90,7 @@ import collections
 from copy import deepcopy
 from module_utils.oneview import OneViewModuleBase, ResourceComparator, HPOneViewValueError
 
-from ansible.compat.six import iteritems
+from six import iteritems
 from ansible.module_utils.basic import AnsibleModule
 
 

--- a/test/test_oneview_server_profile_facts.py
+++ b/test/test_oneview_server_profile_facts.py
@@ -38,6 +38,10 @@ PARAMS_GET_BY_NAME = dict(
     name="Test Server Profile"
 )
 
+PARAMS_GET_BY_URI = dict(
+    config='config.json',
+    uri="/rest/fake"
+)
 PARAMS_WITH_OPTIONS = dict(
     config='config.json',
     name="Test Server Profile",
@@ -135,6 +139,20 @@ class ServerProfileFactsSpec(unittest.TestCase,
         self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(server_profiles=servers)
+        )
+
+    def test_should_get_by_uri(self):
+        server_profile = {"name": "Server Profile Name", 'uri': '/rest/test/123'}
+
+        self.mock_ov_client.server_profiles.get.return_value = server_profile
+
+        self.mock_ansible_module.params = deepcopy(PARAMS_GET_BY_URI)
+
+        ServerProfileFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(server_profiles=[server_profile])
         )
 
     def test_should_get_server_profile_by_name_with_all_options(self):

--- a/test/test_oneview_server_profile_template_facts.py
+++ b/test/test_oneview_server_profile_template_facts.py
@@ -38,6 +38,12 @@ PARAMS_GET_BY_NAME = dict(
     options=None
 )
 
+PARAMS_GET_BY_URI = dict(
+    config='config.json',
+    uri='/rest/fake',
+    options=None
+)
+
 PARAMS_GET_BY_NAME_WITH_NEW_PROFILE = dict(
     config='config.json',
     name=TEMPLATE_NAME,
@@ -106,6 +112,19 @@ class ServerProfileTemplateFactsSpec(unittest.TestCase,
         ServerProfileTemplateFactsModule().run()
 
         self.mock_ov_client.server_profile_templates.get_by_name.assert_called_once_with(name=TEMPLATE_NAME)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(server_profile_templates=[BASIC_TEMPLATE])
+        )
+
+    def test_should_get_template_by_uri(self):
+        self.mock_ov_client.server_profile_templates.get.return_value = BASIC_TEMPLATE
+        self.mock_ansible_module.params = PARAMS_GET_BY_URI
+
+        ServerProfileTemplateFactsModule().run()
+
+        self.mock_ov_client.server_profile_templates.get.assert_called_once_with('/rest/fake')
 
         self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,


### PR DESCRIPTION
### Description
Adds uri parameter to SP facts, allowing a SP to be easily queryable by its uri

### Issues Resolved
#290 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass. (`$ ./build.sh`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in the examples (please include helpful comments).
