### PR TITLE
Update module_utils imports to use 'from ansible.module_utils' standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This release adds the [TESTING.md](TESTING.md) document.
 - [#285](https://github.com/HewlettPackard/oneview-ansible/issues/285) Modules cannot unassign a Server Hardware or create SP with unassigned SH
 - [#288](https://github.com/HewlettPackard/oneview-ansible/issues/288) Adding osCustomAttributes to a SP which had none before results in failure
 - [#290](https://github.com/HewlettPackard/oneview-ansible/issues/290) Issue with filter on oneview_server_profile_facts
+- [#297](https://github.com/HewlettPackard/oneview-ansible/issues/297) Allow specifying a custom path for the module_utils
 
 # v4.0.0
 #### Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This release adds the [TESTING.md](TESTING.md) document.
 
 #### Bug fixes & Enhancements
 - [#172](https://github.com/HewlettPackard/oneview-ansible/issues/172) Allow credentials to be defined inside the playbooks
+- [#273](https://github.com/HewlettPackard/oneview-ansible/issues/273) Investigate probably unused AnsibleModule imports
 - [#282](https://github.com/HewlettPackard/oneview-ansible/issues/282) Updating a Server Profile causes Server Hardware reboots for operations which do not require it
 - [#285](https://github.com/HewlettPackard/oneview-ansible/issues/285) Modules cannot unassign a Server Hardware or create SP with unassigned SH
 - [#288](https://github.com/HewlettPackard/oneview-ansible/issues/288) Adding osCustomAttributes to a SP which had none before results in failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-# v4.0.1
+# v5.0.0
 #### Notes
 This release adds the [TESTING.md](TESTING.md) document.
+
+#### Breaking changes
+1. The PYTHONPATH variable no longer imports the oneview module_utils, now a new ENV variable must be set for the modules to work, the ANSIBLE_MODULE_UTILS variable.
 
 #### Bug fixes & Enhancements
 - [#172](https://github.com/HewlettPackard/oneview-ansible/issues/172) Allow credentials to be defined inside the playbooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This release adds the [TESTING.md](TESTING.md) document.
 
 #### Breaking changes
-1. The PYTHONPATH variable no longer imports the oneview module_utils, now a new ENV variable must be set for the modules to work, the ANSIBLE_MODULE_UTILS variable.
+1. On the modules setup instructions, the requirement of setting up a PYTHONPATH environment variable is being dropped and replaced by the setup of the ANSIBLE_MODULE_UTILS environment variable.
 
 #### Bug fixes & Enhancements
 - [#172](https://github.com/HewlettPackard/oneview-ansible/issues/172) Allow credentials to be defined inside the playbooks

--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ $ git clone https://github.com/HewlettPackard/oneview-ansible.git
 
 ### 2. Configure the ANSIBLE_LIBRARY environmental variable
 
-Set the environment variables `ANSIBLE_LIBRARY` and `PYTHONPATH`, specifying the `library` full path from the cloned project:
+Set the environment variables `ANSIBLE_LIBRARY` and `ANSIBLE_MODULE_UTILS`, specifying the `library` full path from the cloned project:
 
 ```bash
 $ export ANSIBLE_LIBRARY=/path/to/oneview-ansible/library
-$ export PYTHONPATH=$PYTHONPATH:$ANSIBLE_LIBRARY
+$ export ANSIBLE_MODULE_UTILS=/path/to/oneview-ansible/library/module_utils/
 ```
 
 ### 3. OneViewClient Configuration

--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,7 @@ setup () {
   echo ${PYTHON_SDK}
   cd ${BASH_SOURCE%/*}
   export ANSIBLE_LIBRARY=library
+  export ANSIBLE_MODULE_UTILS=$ANSIBLE_LIBRARY/module_utils
 
   if [ -z ${PYTHON_SDK+x} ]; then
     export PYTHON_SDK=../python-hpOneView

--- a/library/hpe_icsp_os_deployment.py
+++ b/library/hpe_icsp_os_deployment.py
@@ -103,7 +103,7 @@ standard_library.install_aliases()
 import time
 import hpICsp
 from ansible.module_utils.basic import AnsibleModule
-from module_utils.icsp import ICspHelper
+from ansible.module_utils.icsp import ICspHelper
 
 
 def deploy_server(module):

--- a/library/hpe_icsp_server.py
+++ b/library/hpe_icsp_server.py
@@ -130,7 +130,7 @@ import json
 import hpICsp
 from hpICsp.exceptions import HPICspException
 from ansible.module_utils.basic import AnsibleModule
-from module_utils.icsp import ICspHelper
+from ansible.module_utils.icsp import ICspHelper
 
 
 class ICspServerModule(object):

--- a/library/image_streamer_artifact_bundle.py
+++ b/library/image_streamer_artifact_bundle.py
@@ -160,8 +160,7 @@ artifact_bundle_deployment_group:
 '''
 
 import os
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, ResourceComparator
+from ansible.module_utils.oneview import OneViewModuleBase, ResourceComparator
 
 
 class ArtifactBundleModule(OneViewModuleBase):

--- a/library/image_streamer_artifact_bundle_facts.py
+++ b/library/image_streamer_artifact_bundle_facts.py
@@ -113,8 +113,7 @@ backup_for_artifact_bundle:
     type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class ArtifactBundleFactsModule(OneViewModuleBase):

--- a/library/image_streamer_build_plan.py
+++ b/library/image_streamer_build_plan.py
@@ -85,8 +85,7 @@ build_plan:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewValueError
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewValueError
 
 
 class BuildPlanModule(OneViewModuleBase):

--- a/library/image_streamer_build_plan_facts.py
+++ b/library/image_streamer_build_plan_facts.py
@@ -76,8 +76,7 @@ build_plans:
     type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class BuildPlanFactsModule(OneViewModuleBase):

--- a/library/image_streamer_deployment_group_facts.py
+++ b/library/image_streamer_deployment_group_facts.py
@@ -79,8 +79,7 @@ deployment_groups:
     type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class DeploymentGroupFactsModule(OneViewModuleBase):

--- a/library/image_streamer_deployment_plan.py
+++ b/library/image_streamer_deployment_plan.py
@@ -86,8 +86,7 @@ deployment_plan:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class DeploymentPlanModule(OneViewModuleBase):

--- a/library/image_streamer_deployment_plan_facts.py
+++ b/library/image_streamer_deployment_plan_facts.py
@@ -76,8 +76,7 @@ deployment_plans:
     type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class DeploymentPlanFactsModule(OneViewModuleBase):

--- a/library/image_streamer_golden_image.py
+++ b/library/image_streamer_golden_image.py
@@ -117,11 +117,7 @@ golden_image:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import (OneViewModuleBase,
-                                  HPOneViewValueError,
-                                  HPOneViewResourceNotFound,
-                                  ResourceComparator)
+from ansible.module_utils.oneview import (OneViewModuleBase, HPOneViewValueError, HPOneViewResourceNotFound, ResourceComparator)
 
 
 class GoldenImageModule(OneViewModuleBase):

--- a/library/image_streamer_golden_image_facts.py
+++ b/library/image_streamer_golden_image_facts.py
@@ -76,8 +76,7 @@ golden_images:
     type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class GoldenImageFactsModule(OneViewModuleBase):

--- a/library/image_streamer_os_volume_facts.py
+++ b/library/image_streamer_os_volume_facts.py
@@ -77,8 +77,7 @@ os_volumes:
     returned: Always, but can be empty.
     type: list
 '''
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class OsVolumeFactsModule(OneViewModuleBase):

--- a/library/image_streamer_plan_script.py
+++ b/library/image_streamer_plan_script.py
@@ -105,8 +105,7 @@ plan_script_differences:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewValueError
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewValueError
 
 
 class PlanScriptModule(OneViewModuleBase):

--- a/library/image_streamer_plan_script_facts.py
+++ b/library/image_streamer_plan_script_facts.py
@@ -76,8 +76,7 @@ plan_scripts:
     type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class PlanScriptFactsModule(OneViewModuleBase):

--- a/library/module_utils/icsp.py
+++ b/library/module_utils/icsp.py
@@ -22,7 +22,7 @@ from __future__ import (absolute_import,
                         unicode_literals)
 
 from future import standard_library
-from urllib.parse import quote
+from six.moves.urllib.parse import quote
 import logging
 
 standard_library.install_aliases()

--- a/library/oneview_alert_facts.py
+++ b/library/oneview_alert_facts.py
@@ -76,8 +76,7 @@ alerts:
     type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class AlertFactsModule(OneViewModuleBase):

--- a/library/oneview_appliance_time_and_locale_configuration.py
+++ b/library/oneview_appliance_time_and_locale_configuration.py
@@ -62,8 +62,7 @@ appliance_time_and_locale_configuration:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class ApplianceTimeAndLocaleConfigurationModule(OneViewModuleBase):

--- a/library/oneview_appliance_time_and_locale_configuration_facts.py
+++ b/library/oneview_appliance_time_and_locale_configuration_facts.py
@@ -51,8 +51,7 @@ appliance_time_and_locale_configuration:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class ApplianceTimeAndLocaleConfigurationFactsModule(OneViewModuleBase):

--- a/library/oneview_connection_template.py
+++ b/library/oneview_connection_template.py
@@ -68,11 +68,7 @@ connection_template:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import (OneViewModuleBase,
-                                  HPOneViewValueError,
-                                  HPOneViewResourceNotFound,
-                                  ResourceComparator)
+from ansible.module_utils.oneview import (OneViewModuleBase, HPOneViewValueError, HPOneViewResourceNotFound, ResourceComparator)
 
 
 class ConnectionTemplateModule(OneViewModuleBase):

--- a/library/oneview_connection_template_facts.py
+++ b/library/oneview_connection_template_facts.py
@@ -93,8 +93,7 @@ default_connection_template:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class ConnectionTemplateFactsModule(OneViewModuleBase):

--- a/library/oneview_datacenter.py
+++ b/library/oneview_datacenter.py
@@ -110,8 +110,7 @@ datacenter:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class DatacenterModule(OneViewModuleBase):

--- a/library/oneview_datacenter_facts.py
+++ b/library/oneview_datacenter_facts.py
@@ -93,8 +93,7 @@ datacenter_visual_content:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class DatacenterFactsModule(OneViewModuleBase):

--- a/library/oneview_drive_enclosure.py
+++ b/library/oneview_drive_enclosure.py
@@ -91,8 +91,7 @@ drive_enclosure:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, HPOneViewValueError
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, HPOneViewValueError
 
 
 class DriveEnclosureModule(OneViewModuleBase):

--- a/library/oneview_drive_enclosure_facts.py
+++ b/library/oneview_drive_enclosure_facts.py
@@ -98,8 +98,7 @@ drive_enclosure_port_map:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class DriveEnclosureFactsModule(OneViewModuleBase):

--- a/library/oneview_enclosure.py
+++ b/library/oneview_enclosure.py
@@ -268,8 +268,7 @@ enclosure:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class EnclosureModule(OneViewModuleBase):

--- a/library/oneview_enclosure_facts.py
+++ b/library/oneview_enclosure_facts.py
@@ -150,8 +150,7 @@ enclosure_utilization:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class EnclosureFactsModule(OneViewModuleBase):

--- a/library/oneview_enclosure_group.py
+++ b/library/oneview_enclosure_group.py
@@ -91,8 +91,7 @@ enclosure_group:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class EnclosureGroupModule(OneViewModuleBase):

--- a/library/oneview_enclosure_group_facts.py
+++ b/library/oneview_enclosure_group_facts.py
@@ -93,8 +93,7 @@ enclosure_group_script:
     type: string
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class EnclosureGroupFactsModule(OneViewModuleBase):

--- a/library/oneview_ethernet_network.py
+++ b/library/oneview_ethernet_network.py
@@ -135,8 +135,7 @@ ethernet_network_connection_template:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, ResourceComparator, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, ResourceComparator, HPOneViewResourceNotFound
 
 
 class EthernetNetworkModule(OneViewModuleBase):

--- a/library/oneview_ethernet_network_facts.py
+++ b/library/oneview_ethernet_network_facts.py
@@ -103,8 +103,7 @@ enet_associated_uplink_groups:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class EthernetNetworkFactsModule(OneViewModuleBase):

--- a/library/oneview_event.py
+++ b/library/oneview_event.py
@@ -68,8 +68,7 @@ event:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class EventModule(OneViewModuleBase):

--- a/library/oneview_event_facts.py
+++ b/library/oneview_event_facts.py
@@ -69,8 +69,7 @@ events:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class EventFactsModule(OneViewModuleBase):

--- a/library/oneview_fabric.py
+++ b/library/oneview_fabric.py
@@ -65,8 +65,7 @@ fabric:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, ResourceComparator
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, ResourceComparator
 
 
 class FabricModule(OneViewModuleBase):

--- a/library/oneview_fabric_facts.py
+++ b/library/oneview_fabric_facts.py
@@ -92,8 +92,7 @@ fabric_reserved_vlan_range:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class FabricFactsModule(OneViewModuleBase):

--- a/library/oneview_fc_network.py
+++ b/library/oneview_fc_network.py
@@ -91,8 +91,7 @@ fc_network:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class FcNetworkModule(OneViewModuleBase):

--- a/library/oneview_fc_network_facts.py
+++ b/library/oneview_fc_network_facts.py
@@ -78,8 +78,7 @@ fc_networks:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class FcNetworkFactsModule(OneViewModuleBase):

--- a/library/oneview_fcoe_network.py
+++ b/library/oneview_fcoe_network.py
@@ -89,8 +89,7 @@ fcoe_network:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class FcoeNetworkModule(OneViewModuleBase):

--- a/library/oneview_fcoe_network_facts.py
+++ b/library/oneview_fcoe_network_facts.py
@@ -81,8 +81,7 @@ fcoe_networks:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class FcoeNetworkFactsModule(OneViewModuleBase):

--- a/library/oneview_firmware_bundle.py
+++ b/library/oneview_firmware_bundle.py
@@ -64,8 +64,7 @@ firmware_bundle:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class FirmwareBundleModule(OneViewModuleBase):

--- a/library/oneview_firmware_driver.py
+++ b/library/oneview_firmware_driver.py
@@ -78,8 +78,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import (OneViewModuleBase, HPOneViewException)
+from ansible.module_utils.oneview import (OneViewModuleBase, HPOneViewException)
 
 
 class FirmwareDriverModule(OneViewModuleBase):

--- a/library/oneview_firmware_driver_facts.py
+++ b/library/oneview_firmware_driver_facts.py
@@ -80,8 +80,7 @@ firmware_drivers:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class FirmwareDriverFactsModule(OneViewModuleBase):

--- a/library/oneview_id_pools_ipv4_range.py
+++ b/library/oneview_id_pools_ipv4_range.py
@@ -71,8 +71,7 @@ id_pools_ipv4_range:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewValueError, ResourceComparator
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewValueError, ResourceComparator
 
 
 class IdPoolsIpv4RangeModule(OneViewModuleBase):

--- a/library/oneview_id_pools_ipv4_range_facts.py
+++ b/library/oneview_id_pools_ipv4_range_facts.py
@@ -117,8 +117,7 @@ id_pools_ipv4_ranges_allocated_fragments:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class IdPoolsIpv4RangeFactsModule(OneViewModuleBase):

--- a/library/oneview_id_pools_ipv4_subnet.py
+++ b/library/oneview_id_pools_ipv4_subnet.py
@@ -72,8 +72,7 @@ id_pools_ipv4_subnet:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewValueError, ResourceComparator
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewValueError, ResourceComparator
 
 
 class IdPoolsIpv4SubnetModule(OneViewModuleBase):

--- a/library/oneview_id_pools_ipv4_subnet_facts.py
+++ b/library/oneview_id_pools_ipv4_subnet_facts.py
@@ -78,8 +78,7 @@ id_pools_ipv4_subnets:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class IdPoolsIpv4SubnetFactsModule(OneViewModuleBase):

--- a/library/oneview_interconnect.py
+++ b/library/oneview_interconnect.py
@@ -104,10 +104,7 @@ interconnect:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import (OneViewModuleBase,
-                                  HPOneViewResourceNotFound,
-                                  HPOneViewValueError)
+from ansible.module_utils.oneview import (OneViewModuleBase, HPOneViewResourceNotFound, HPOneViewValueError)
 from hpOneView.resources.resource import extract_id_from_uri
 
 

--- a/library/oneview_interconnect_facts.py
+++ b/library/oneview_interconnect_facts.py
@@ -197,8 +197,7 @@ interconnect_pluggable_module_information:
     type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 from hpOneView.resources.resource import extract_id_from_uri
 
 

--- a/library/oneview_interconnect_link_topology_facts.py
+++ b/library/oneview_interconnect_link_topology_facts.py
@@ -75,8 +75,7 @@ interconnect_link_topologies:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class InterconnectLinkTopologyFactsModule(OneViewModuleBase):

--- a/library/oneview_interconnect_type_facts.py
+++ b/library/oneview_interconnect_type_facts.py
@@ -74,8 +74,7 @@ interconnect_types:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class InterconnectTypeFactsModule(OneViewModuleBase):

--- a/library/oneview_internal_link_set_facts.py
+++ b/library/oneview_internal_link_set_facts.py
@@ -88,8 +88,7 @@ internal_link_sets:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class InternalLinkSetFactsModule(OneViewModuleBase):

--- a/library/oneview_logical_downlinks_facts.py
+++ b/library/oneview_logical_downlinks_facts.py
@@ -89,8 +89,7 @@ logical_downlinks:
     type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class LogicalDownlinksFactsModule(OneViewModuleBase):

--- a/library/oneview_logical_enclosure.py
+++ b/library/oneview_logical_enclosure.py
@@ -175,8 +175,7 @@ generated_dump_uri:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, ResourceComparator
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, ResourceComparator
 
 
 class LogicalEnclosureModule(OneViewModuleBase):

--- a/library/oneview_logical_enclosure_facts.py
+++ b/library/oneview_logical_enclosure_facts.py
@@ -100,8 +100,7 @@ logical_enclosure_script:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class LogicalEnclosureFactsModule(OneViewModuleBase):

--- a/library/oneview_logical_interconnect.py
+++ b/library/oneview_logical_interconnect.py
@@ -231,11 +231,7 @@ scope_uris:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import (OneViewModuleBase,
-                                  HPOneViewResourceNotFound,
-                                  ResourceComparator,
-                                  HPOneViewValueError)
+from ansible.module_utils.oneview import (OneViewModuleBase, HPOneViewResourceNotFound, ResourceComparator, HPOneViewValueError)
 
 
 class LogicalInterconnectModule(OneViewModuleBase):

--- a/library/oneview_logical_interconnect.py
+++ b/library/oneview_logical_interconnect.py
@@ -231,7 +231,7 @@ scope_uris:
     type: dict
 '''
 
-from ansible.module_utils.oneview import (OneViewModuleBase, HPOneViewResourceNotFound, ResourceComparator, HPOneViewValueError)
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, ResourceComparator, HPOneViewValueError
 
 
 class LogicalInterconnectModule(OneViewModuleBase):

--- a/library/oneview_logical_interconnect_facts.py
+++ b/library/oneview_logical_interconnect_facts.py
@@ -168,8 +168,7 @@ ethernet_settings:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class LogicalInterconnectFactsModule(OneViewModuleBase):

--- a/library/oneview_logical_interconnect_group.py
+++ b/library/oneview_logical_interconnect_group.py
@@ -101,8 +101,7 @@ logical_interconnect_group:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class LogicalInterconnectGroupModule(OneViewModuleBase):

--- a/library/oneview_logical_interconnect_group_facts.py
+++ b/library/oneview_logical_interconnect_group_facts.py
@@ -94,8 +94,7 @@ logical_interconnect_groups:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class LogicalInterconnectGroupFactsModule(OneViewModuleBase):

--- a/library/oneview_logical_switch.py
+++ b/library/oneview_logical_switch.py
@@ -157,8 +157,7 @@ logical_switch:
 
 from copy import deepcopy
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewException, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewException, HPOneViewResourceNotFound
 
 
 class LogicalSwitchModule(OneViewModuleBase):

--- a/library/oneview_logical_switch_facts.py
+++ b/library/oneview_logical_switch_facts.py
@@ -77,8 +77,7 @@ logical_switches:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class LogicalSwitchFactsModule(OneViewModuleBase):

--- a/library/oneview_logical_switch_group.py
+++ b/library/oneview_logical_switch_group.py
@@ -104,8 +104,7 @@ logical_switch_group:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class LogicalSwitchGroupModule(OneViewModuleBase):

--- a/library/oneview_logical_switch_group_facts.py
+++ b/library/oneview_logical_switch_group_facts.py
@@ -79,8 +79,7 @@ logical_switch_groups:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class LogicalSwitchGroupFactsModule(OneViewModuleBase):

--- a/library/oneview_managed_san.py
+++ b/library/oneview_managed_san.py
@@ -118,8 +118,7 @@ managed_san_issues:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, ResourceComparator
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, ResourceComparator
 
 
 class ManagedSanModule(OneViewModuleBase):

--- a/library/oneview_managed_san_facts.py
+++ b/library/oneview_managed_san_facts.py
@@ -125,8 +125,7 @@ wwn_associated_sans:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class ManagedSanFactsModule(OneViewModuleBase):

--- a/library/oneview_network_set.py
+++ b/library/oneview_network_set.py
@@ -95,8 +95,7 @@ network_set:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class NetworkSetModule(OneViewModuleBase):

--- a/library/oneview_network_set_facts.py
+++ b/library/oneview_network_set_facts.py
@@ -129,8 +129,7 @@ network_sets:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class NetworkSetFactsModule(OneViewModuleBase):

--- a/library/oneview_os_deployment_plan_facts.py
+++ b/library/oneview_os_deployment_plan_facts.py
@@ -100,8 +100,7 @@ os_deployment_plan_custom_attributes:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 from six import iteritems
 
 

--- a/library/oneview_os_deployment_server.py
+++ b/library/oneview_os_deployment_server.py
@@ -88,8 +88,7 @@ os_deployment_server:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, ResourceComparator
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, ResourceComparator
 
 
 class OsDeploymentServerModule(OneViewModuleBase):

--- a/library/oneview_os_deployment_server_facts.py
+++ b/library/oneview_os_deployment_server_facts.py
@@ -114,8 +114,7 @@ os_deployment_server_appliance:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class OsDeploymentServerFactsModule(OneViewModuleBase):

--- a/library/oneview_power_device.py
+++ b/library/oneview_power_device.py
@@ -121,8 +121,7 @@ power_device:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewValueError, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewValueError, HPOneViewResourceNotFound
 
 
 class PowerDeviceModule(OneViewModuleBase):

--- a/library/oneview_power_device_facts.py
+++ b/library/oneview_power_device_facts.py
@@ -133,8 +133,7 @@ power_device_utilization:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class PowerDeviceFactsModule(OneViewModuleBase):

--- a/library/oneview_rack.py
+++ b/library/oneview_rack.py
@@ -94,8 +94,7 @@ rack:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class RackModule(OneViewModuleBase):

--- a/library/oneview_rack_facts.py
+++ b/library/oneview_rack_facts.py
@@ -93,8 +93,7 @@ rack_device_topology:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class RackFactsModule(OneViewModuleBase):

--- a/library/oneview_san_manager.py
+++ b/library/oneview_san_manager.py
@@ -108,8 +108,7 @@ san_manager:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewValueError, ResourceComparator
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewValueError, ResourceComparator
 
 # To activate logs, setup the environment var LOGFILE
 # e.g.: export LOGFILE=/tmp/ansible-oneview.log

--- a/library/oneview_san_manager_facts.py
+++ b/library/oneview_san_manager_facts.py
@@ -88,8 +88,7 @@ san_managers:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class SanManagerFactsModule(OneViewModuleBase):

--- a/library/oneview_sas_interconnect.py
+++ b/library/oneview_sas_interconnect.py
@@ -77,8 +77,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class SasInterconnectModule(OneViewModuleBase):

--- a/library/oneview_sas_interconnect_facts.py
+++ b/library/oneview_sas_interconnect_facts.py
@@ -69,8 +69,7 @@ sas_interconnects:
     type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class SasInterconnectFactsModule(OneViewModuleBase):

--- a/library/oneview_sas_interconnect_type_facts.py
+++ b/library/oneview_sas_interconnect_type_facts.py
@@ -77,8 +77,7 @@ sas_interconnect_types:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class SasInterconnectTypeFactsModule(OneViewModuleBase):

--- a/library/oneview_sas_logical_interconnect.py
+++ b/library/oneview_sas_logical_interconnect.py
@@ -120,8 +120,7 @@ li_firmware:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, HPOneViewValueError
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, HPOneViewValueError
 
 
 class SasLogicalInterconnectModule(OneViewModuleBase):

--- a/library/oneview_sas_logical_interconnect_facts.py
+++ b/library/oneview_sas_logical_interconnect_facts.py
@@ -99,8 +99,7 @@ sas_logical_interconnect_firmware:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class SasLogicalInterconnectFactsModule(OneViewModuleBase):

--- a/library/oneview_sas_logical_interconnect_group.py
+++ b/library/oneview_sas_logical_interconnect_group.py
@@ -103,8 +103,7 @@ sas_logical_interconnect_group:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class SasLogicalInterconnectGroupModule(OneViewModuleBase):

--- a/library/oneview_sas_logical_interconnect_group_facts.py
+++ b/library/oneview_sas_logical_interconnect_group_facts.py
@@ -74,8 +74,7 @@ sas_logical_interconnect_groups:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class SasLogicalInterconnectGroupFactsModule(OneViewModuleBase):

--- a/library/oneview_sas_logical_jbod_attachment_facts.py
+++ b/library/oneview_sas_logical_jbod_attachment_facts.py
@@ -78,8 +78,7 @@ sas_logical_jbod_attachments:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class SasLogicalJbodAttachmentFactsModule(OneViewModuleBase):

--- a/library/oneview_sas_logical_jbod_facts.py
+++ b/library/oneview_sas_logical_jbod_facts.py
@@ -97,8 +97,7 @@ sas_logical_jbod_drives:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class SasLogicalJbodFactsModule(OneViewModuleBase):

--- a/library/oneview_scope.py
+++ b/library/oneview_scope.py
@@ -111,8 +111,7 @@ scope:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class ScopeModule(OneViewModuleBase):

--- a/library/oneview_scope_facts.py
+++ b/library/oneview_scope_facts.py
@@ -93,8 +93,7 @@ scopes:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class ScopeFactsModule(OneViewModuleBase):

--- a/library/oneview_server_hardware.py
+++ b/library/oneview_server_hardware.py
@@ -145,8 +145,7 @@ server_hardware:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, HPOneViewValueError
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, HPOneViewValueError
 
 
 class ServerHardwareModule(OneViewModuleBase):

--- a/library/oneview_server_hardware_facts.py
+++ b/library/oneview_server_hardware_facts.py
@@ -184,8 +184,7 @@ server_hardware_physical_server_hardware:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class ServerHardwareFactsModule(OneViewModuleBase):

--- a/library/oneview_server_hardware_type.py
+++ b/library/oneview_server_hardware_type.py
@@ -84,8 +84,7 @@ server_hardware_type:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class ServerHardwareTypeModule(OneViewModuleBase):

--- a/library/oneview_server_hardware_type_facts.py
+++ b/library/oneview_server_hardware_type_facts.py
@@ -75,8 +75,7 @@ server_hardware_types:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class ServerHardwareTypeFactsModule(OneViewModuleBase):

--- a/library/oneview_server_profile.py
+++ b/library/oneview_server_profile.py
@@ -202,15 +202,14 @@ import time
 
 from copy import deepcopy
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import (OneViewModuleBase,
-                                  ServerProfileReplaceNamesByUris,
-                                  HPOneViewValueError,
-                                  ServerProfileMerger,
-                                  ResourceComparator,
-                                  HPOneViewTaskError,
-                                  SPKeys,
-                                  HPOneViewException)
+from ansible.module_utils.oneview import (OneViewModuleBase,
+                                          ServerProfileReplaceNamesByUris,
+                                          HPOneViewValueError,
+                                          ServerProfileMerger,
+                                          ResourceComparator,
+                                          HPOneViewTaskError,
+                                          SPKeys,
+                                          HPOneViewException)
 
 # To activate logs, setup the environment var LOGFILE
 # e.g.: export LOGFILE=/tmp/ansible-oneview.log

--- a/library/oneview_server_profile_facts.py
+++ b/library/oneview_server_profile_facts.py
@@ -221,8 +221,7 @@ server_profile_available_targets:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class ServerProfileFactsModule(OneViewModuleBase):

--- a/library/oneview_server_profile_template.py
+++ b/library/oneview_server_profile_template.py
@@ -98,7 +98,7 @@ server_profile_template:
     type: dict
 '''
 
-from ansible.module_utils.oneview import (OneViewModuleBase, ServerProfileReplaceNamesByUris, ServerProfileMerger, ResourceComparator)
+from ansible.module_utils.oneview import OneViewModuleBase, ServerProfileReplaceNamesByUris, ServerProfileMerger, ResourceComparator
 
 # To activate logs, setup the environment var LOGFILE
 # e.g.: export LOGFILE=/tmp/ansible-oneview.log

--- a/library/oneview_server_profile_template.py
+++ b/library/oneview_server_profile_template.py
@@ -98,11 +98,7 @@ server_profile_template:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import (OneViewModuleBase,
-                                  ServerProfileReplaceNamesByUris,
-                                  ServerProfileMerger,
-                                  ResourceComparator)
+from ansible.module_utils.oneview import (OneViewModuleBase, ServerProfileReplaceNamesByUris, ServerProfileMerger, ResourceComparator)
 
 # To activate logs, setup the environment var LOGFILE
 # e.g.: export LOGFILE=/tmp/ansible-oneview.log

--- a/library/oneview_server_profile_template_facts.py
+++ b/library/oneview_server_profile_template_facts.py
@@ -99,8 +99,7 @@ new_profile:
     returned: When requested, but can be null.
     type: dict
 '''
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class ServerProfileTemplateFactsModule(OneViewModuleBase):

--- a/library/oneview_storage_pool.py
+++ b/library/oneview_storage_pool.py
@@ -96,8 +96,7 @@ storage_pool:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewValueError, HPOneViewResourceNotFound, ResourceComparator
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewValueError, HPOneViewResourceNotFound, ResourceComparator
 
 
 class StoragePoolModule(OneViewModuleBase):

--- a/library/oneview_storage_pool_facts.py
+++ b/library/oneview_storage_pool_facts.py
@@ -104,8 +104,7 @@ storage_pools_reachable_storage_pools:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class StoragePoolFactsModule(OneViewModuleBase):

--- a/library/oneview_storage_system.py
+++ b/library/oneview_storage_system.py
@@ -113,8 +113,7 @@ storage_system:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewValueError, ResourceComparator
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewValueError, ResourceComparator
 
 
 class StorageSystemModule(OneViewModuleBase):

--- a/library/oneview_storage_system_facts.py
+++ b/library/oneview_storage_system_facts.py
@@ -163,8 +163,7 @@ storage_system_templates:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class StorageSystemFactsModule(OneViewModuleBase):

--- a/library/oneview_storage_volume_attachment.py
+++ b/library/oneview_storage_volume_attachment.py
@@ -74,8 +74,7 @@ server_profile:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class StorageVolumeAttachmentModule(OneViewModuleBase):

--- a/library/oneview_storage_volume_attachment_facts.py
+++ b/library/oneview_storage_volume_attachment_facts.py
@@ -152,8 +152,7 @@ storage_volume_attachment_paths:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewValueError
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewValueError
 
 SPECIFIC_ATTACHMENT_OPTIONS = ['storageVolumeAttachmentUri', 'storageVolumeUri', 'storageVolumeName',
                                'serverProfileName']

--- a/library/oneview_storage_volume_template.py
+++ b/library/oneview_storage_volume_template.py
@@ -88,10 +88,9 @@ storage_volume_template:
 import collections
 
 from copy import deepcopy
-from module_utils.oneview import OneViewModuleBase, ResourceComparator, HPOneViewValueError
-
 from six import iteritems
-from ansible.module_utils.basic import AnsibleModule
+
+from ansible.module_utils.oneview import OneViewModuleBase, ResourceComparator, HPOneViewValueError
 
 
 def _update_dict_with_depth(ov_resource, user_resource):

--- a/library/oneview_storage_volume_template_facts.py
+++ b/library/oneview_storage_volume_template_facts.py
@@ -124,8 +124,7 @@ compatible_systems:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class StorageVolumeTemplateFactsModule(OneViewModuleBase):

--- a/library/oneview_switch.py
+++ b/library/oneview_switch.py
@@ -65,8 +65,7 @@ EXAMPLES = '''
 
 RETURN = ''' # '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class SwitchModule(OneViewModuleBase):

--- a/library/oneview_switch_facts.py
+++ b/library/oneview_switch_facts.py
@@ -89,8 +89,7 @@ switch_environmental_configuration:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class SwitchFactsModule(OneViewModuleBase):

--- a/library/oneview_switch_type_facts.py
+++ b/library/oneview_switch_type_facts.py
@@ -75,8 +75,7 @@ switch_types:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class SwitchTypeFactsModule(OneViewModuleBase):

--- a/library/oneview_task_facts.py
+++ b/library/oneview_task_facts.py
@@ -66,8 +66,7 @@ tasks:
     type: list
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class TaskFactsModule(OneViewModuleBase):

--- a/library/oneview_unmanaged_device.py
+++ b/library/oneview_unmanaged_device.py
@@ -107,8 +107,7 @@ unmanaged_device:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class UnmanagedDeviceModule(OneViewModuleBase):

--- a/library/oneview_unmanaged_device_facts.py
+++ b/library/oneview_unmanaged_device_facts.py
@@ -94,8 +94,7 @@ unmanaged_device_environmental_configuration:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class UnmanagedDeviceFactsModule(OneViewModuleBase):

--- a/library/oneview_uplink_set.py
+++ b/library/oneview_uplink_set.py
@@ -98,7 +98,7 @@ uplink_set:
     returned: On state 'present'. Can be null.
     type: dict
 '''
-from ansible.module_utils.oneview import (OneViewModuleBase, HPOneViewResourceNotFound, HPOneViewValueError)
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound, HPOneViewValueError
 
 
 class UplinkSetModule(OneViewModuleBase):

--- a/library/oneview_uplink_set.py
+++ b/library/oneview_uplink_set.py
@@ -98,10 +98,7 @@ uplink_set:
     returned: On state 'present'. Can be null.
     type: dict
 '''
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import (OneViewModuleBase,
-                                  HPOneViewResourceNotFound,
-                                  HPOneViewValueError)
+from ansible.module_utils.oneview import (OneViewModuleBase, HPOneViewResourceNotFound, HPOneViewValueError)
 
 
 class UplinkSetModule(OneViewModuleBase):

--- a/library/oneview_uplink_set_facts.py
+++ b/library/oneview_uplink_set_facts.py
@@ -73,8 +73,7 @@ uplink_sets:
     returned: Always, but can be null.
     type: dict
 '''
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewResourceNotFound
 
 
 class UplinkSetFactsModule(OneViewModuleBase):

--- a/library/oneview_user.py
+++ b/library/oneview_user.py
@@ -95,8 +95,7 @@ user:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, ResourceComparator
+from ansible.module_utils.oneview import OneViewModuleBase, ResourceComparator
 from hpOneView.exceptions import HPOneViewException
 
 

--- a/library/oneview_user_facts.py
+++ b/library/oneview_user_facts.py
@@ -76,8 +76,7 @@ users:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class UserFactsModule(OneViewModuleBase):

--- a/library/oneview_volume.py
+++ b/library/oneview_volume.py
@@ -173,8 +173,7 @@ storage_volume:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase, HPOneViewValueError, HPOneViewResourceNotFound, HPOneViewException
+from ansible.module_utils.oneview import OneViewModuleBase, HPOneViewValueError, HPOneViewResourceNotFound, HPOneViewException
 
 
 class VolumeModule(OneViewModuleBase):

--- a/library/oneview_volume_facts.py
+++ b/library/oneview_volume_facts.py
@@ -118,8 +118,7 @@ extra_managed_volume_paths:
     type: dict
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from module_utils.oneview import OneViewModuleBase
+from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class VolumeFactsModule(OneViewModuleBase):

--- a/oneview-ansible.md
+++ b/oneview-ansible.md
@@ -261,14 +261,14 @@ Manage the Artifact Bundle resource.
  Provides an interface to manage the Artifact Bundle. Can create, update, remove, and download, upload, extract
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Artifact Bundle properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li>  <li>downloaded</li>  <li>archive_downloaded</li>  <li>backup_uploaded</li>  <li>backup_created</li>  <li>extracted</li>  <li>backup_extracted</li> </ul> |  Indicates the desired state for the Artifact Bundle resource. `present` will ensure data properties are compliant with OneView. When the artifact bundle already exists, only the name is updated. Changes in any other attribute value is ignored. `absent` will remove the resource from OneView, if it exists. `downloaded` will download the Artifact Bundle to the file path provided. `archive_downloaded` will download the Artifact Bundle archive to the file path provided. `backup_uploaded` will upload the Backup for the Artifact Bundle from the file path provided. `backup_created` will create a Backup for the Artifact Bundle. `extracted` will extract an Artifact Bundle. `backup_extracted` will extract an Artifact Bundle from the Backup.  |
 
@@ -386,8 +386,6 @@ Manage the Artifact Bundle resource.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -399,17 +397,17 @@ Retrieve facts about the Artifact Bundle.
  Retrieve facts about the Artifact Bundle.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.1
   * python >= 2.7.9
+  * hpOneView >= 3.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of the Artifact Bundle.  |
 | options  |   No  |  | |  List with options to gather additional facts about the Artifact Bundle. Options allowed: `allBackups` gets the list of backups for the Artifact Bundles. `backupForAnArtifactBundle` gets the list of backups for the Artifact Bundle.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -482,8 +480,6 @@ Retrieve facts about the Artifact Bundle.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -495,14 +491,14 @@ Manages Image Stream OS Build Plan resources.
  Provides an interface to manage Image Stream OS Build Plans. Can create, update, and remove.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with OS Build Plan properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the OS Build Plan resource. `present` will ensure data properties are compliant with Synergy Image Streamer. `absent` will remove the resource from Synergy Image Streamer, if it exists.  |
 
@@ -559,8 +555,6 @@ Manages Image Stream OS Build Plan resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -572,16 +566,16 @@ Retrieve facts about one or more of the Image Streamer Build Plans.
  Retrieve facts about one or more of the Image Streamer Build Plans.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.1
   * python >= 2.7.9
+  * hpOneView >= 3.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Build Plan name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -632,8 +626,6 @@ Retrieve facts about one or more of the Image Streamer Build Plans.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -645,16 +637,16 @@ Retrieve facts about the Image Streamer Deployment Groups.
  Retrieve facts about the Image Streamer Deployment Groups.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.1
   * python >= 2.7.9
+  * hpOneView >= 3.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of the Deployment Group.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -708,8 +700,6 @@ Retrieve facts about the Image Streamer Deployment Groups.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -721,14 +711,14 @@ Manage Image Streamer Deployment Plan resources.
  Provides an interface to manage Image Streamer Deployment Plans. Can create, update, and remove.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Deployment Plan properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Deployment Plan resource. `present` will ensure data properties are compliant with Synergy Image Streamer. `absent` will remove the resource from Synergy Image Streamer, if it exists.  |
 
@@ -786,8 +776,6 @@ Manage Image Streamer Deployment Plan resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -799,16 +787,16 @@ Retrieve facts about the Image Streamer Deployment Plans.
  Retrieve facts about one or more of the Image Streamer Deployment Plans.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.1
   * python >= 2.7.9
+  * hpOneView >= 3.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Deployment Plan name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -859,8 +847,6 @@ Retrieve facts about the Image Streamer Deployment Plans.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -872,14 +858,14 @@ Manage Image Streamer Golden Image resources.
  Provides an interface to manage Image Streamer Golden Image. Can create, add, update, and remove.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Golden Image properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li>  <li>downloaded</li>  <li>archive_downloaded</li> </ul> |  Indicates the desired state for the Golden Image resource. `present` will ensure data properties are compliant with Synergy Image Streamer. `absent` will remove the resource from Synergy Image Streamer, if it exists. `downloaded` will download the Golden Image to the file path provided. `archive_downloaded` will download the Golden Image archive to the file path provided.  |
 
@@ -966,8 +952,6 @@ Manage Image Streamer Golden Image resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -979,16 +963,16 @@ Retrieve facts about one or more of the Image Streamer Golden Image.
  Retrieve facts about one or more of the Image Streamer Golden Image.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.1
   * python >= 2.7.9
+  * hpOneView >= 3.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Golden Image name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -1039,8 +1023,6 @@ Retrieve facts about one or more of the Image Streamer Golden Image.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1052,16 +1034,16 @@ Retrieve facts about the Image Streamer OS Volumes.
  Retrieve facts about the Image Streamer OS Volumes.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.1
   * python >= 2.7.9
+  * hpOneView >= 3.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of the OS Volume.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -1115,8 +1097,6 @@ Retrieve facts about the Image Streamer OS Volumes.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1128,14 +1108,14 @@ Manage the Image Streamer Plan Script resources.
  Provides an interface to manage the Image Streamer Plan Script. Can create, update, and remove.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Plan Script properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li>  <li>differences_retrieved</li> </ul> |  Indicates the desired state for the Plan Script resource. `present` will ensure data properties are compliant with Synergy Image Streamer. `absent` will remove the resource from Synergy Image Streamer, if it exists. `differences_retrieved` will retrieve the modified contents of the Plan Script as per the selected attributes.  |
 
@@ -1206,8 +1186,6 @@ Manage the Image Streamer Plan Script resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1219,16 +1197,16 @@ Retrieve facts about the Image Streamer Plan Scripts.
  Retrieve facts about one or more of the Image Streamer Plan Script.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.1
   * python >= 2.7.9
+  * hpOneView >= 3.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Plan Script name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -1279,8 +1257,6 @@ Retrieve facts about the Image Streamer Plan Scripts.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1292,14 +1268,14 @@ Retrieve facts about the OneView Alerts.
  Retrieve facts about the OneView Alerts.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | params  |   No  |  | |  List with parameters to help filter the alerts. Params allowed: `count`, `fields`, `filter`, `query`, `sort`, `start`, and `view`.  |
 
 
@@ -1353,8 +1329,6 @@ Retrieve facts about the OneView Alerts.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1366,14 +1340,14 @@ Manage OneView Appliance Locale and Time Configuration.
  Provides an interface to manage Appliance Locale and Time Configuration. It can only update it.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.2.0
   * python >= 2.7.9
+  * hpOneView >= 3.2.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the Appliance Locale and Time Configuration properties.  |
 | state  |   |  | <ul> <li>present</li> </ul> |  Indicates the desired state for the Appliance Locale and Time Configuration. `present` will ensure data properties are compliant with OneView.  |
 
@@ -1409,8 +1383,6 @@ Manage OneView Appliance Locale and Time Configuration.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1422,14 +1394,14 @@ Retrieve the facts about the OneView appliance time and locale configuration.
  Retrieve the facts about the OneView appliance time and locale configuration.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.2.0
   * python >= 2.7.9
+  * hpOneView >= 3.2.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 
 
  
@@ -1462,8 +1434,6 @@ Retrieve the facts about the OneView appliance time and locale configuration.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1475,14 +1445,14 @@ Manage the OneView Connection Template resources.
  Provides an interface to manage the Connection Template resources. Can update.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Connection Template properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li> </ul> |  Indicates the desired state for the Connection Template resource. `present` will ensure data properties are compliant with OneView.  |
 
@@ -1524,8 +1494,6 @@ Manage the OneView Connection Template resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1537,17 +1505,17 @@ Retrieve facts about the OneView Connection Templates.
  Retrieve facts about the OneView Connection Templates.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Connection Template name.  |
 | options  |   No  |  | |  List with options to gather additional facts about Connection Template related resources. Options allowed: `defaultConnectionTemplate`.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -1607,8 +1575,6 @@ Retrieve facts about the OneView Connection Templates.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1620,14 +1586,14 @@ Manage OneView Data Center resources.
  Provides an interface to manage Data Center resources. Can add, update, and remove.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Data Center properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Data Center resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -1709,8 +1675,6 @@ Manage OneView Data Center resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1722,17 +1686,17 @@ Retrieve facts about the OneView Data Centers.
  Retrieve facts about the OneView Data Centers.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Data Center name.  |
 | options  |   No  |  | |  Retrieve additional facts. Options available: 'visualContent'.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -1793,8 +1757,6 @@ Retrieve facts about the OneView Data Centers.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1806,14 +1768,14 @@ Manage OneView Drive Enclosure resources.
  Provides an interface to manage Drive Enclosure resources.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the Drive Enclosure properties.  |
 | state  |   |  | <ul> <li>power_state_set</li>  <li>uid_state_set</li>  <li>hard_reset_state_set</li>  <li>refresh_state_set</li> </ul> |  Indicates the desired state for the Drive Enclosure resource. `power_state_set` will set the power state for the Drive Enclosure. `uid_state_set` will set the uid state for the Drive Enclosure. `hard_reset_state_set` will request a hard reset of the Drive Enclosure. `refresh_state_set` will refresh a Drive Enclosure.  |
 
@@ -1875,8 +1837,6 @@ Manage OneView Drive Enclosure resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1888,17 +1848,17 @@ Retrieve the facts about one or more of the OneView Drive Enclosures.
  Retrieve the facts about one or more of the Drive Enclosures from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Drive Enclosure name.  |
 | options  |   No  |  | |  List with options to gather additional facts about Drive Enclosure related resources. Options allowed: `portMap`. To gather additional facts it is required to inform the Drive Enclosure name. Otherwise, these options will be ignored.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -1962,8 +1922,6 @@ Retrieve the facts about one or more of the OneView Drive Enclosures.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -1975,14 +1933,14 @@ Manage OneView Enclosure resources.
  Provides an interface to manage Enclosure resources.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the Enclosure properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li>  <li>reconfigured</li>  <li>refreshed</li>  <li>appliance_bays_powered_on</li>  <li>uid_on</li>  <li>uid_off</li>  <li>manager_bays_uid_on</li>  <li>manager_bays_uid_off</li>  <li>manager_bays_power_state_e_fuse</li>  <li>manager_bays_power_state_reset</li>  <li>appliance_bays_power_state_e_fuse</li>  <li>device_bays_power_state_e_fuse</li>  <li>device_bays_power_state_reset</li>  <li>interconnect_bays_power_state_e_fuse</li>  <li>manager_bays_role_active</li>  <li>device_bays_ipv4_removed</li>  <li>interconnect_bays_ipv4_removed</li>  <li>support_data_collection_set</li> </ul> |  Indicates the desired state for the Enclosure resource. `present` will ensure data properties are compliant with OneView. You can rename the enclosure providing an attribute `newName`. You can also rename the rack providing an attribute `rackName`. `absent` will remove the resource from OneView, if it exists. `reconfigured` will reapply the appliance's configuration on the enclosure. This includes running the same configuration steps that were performed as part of the enclosure add. `refreshed` will refresh the enclosure along with all of its components, including interconnects and servers. Any new hardware is added, and any hardware that is no longer present within the enclosure is removed. `appliance_bays_powered_on` will set the appliance bay power state on. `uid_on` will set the UID state on. `uid_off` will set the UID state off. `manager_bays_uid_on` will set the UID state on for the Synergy Frame Link Module. `manager_bays_uid_off` will set the UID state off for the Synergy Frame Link Module. `manager_bays_power_state_e_fuse` will E-Fuse the Synergy Frame Link Module bay in the path. `manager_bays_power_state_reset` will Reset the Synergy Frame Link Module bay in the path. `appliance_bays_power_state_e_fuse` will E-Fuse the appliance bay in the path. `device_bays_power_state_e_fuse` will E-Fuse the device bay in the path. `device_bays_power_state_reset` will Reset the device bay in the path. `interconnect_bays_power_state_e_fuse` will E-Fuse the IC bay in the path. `manager_bays_role_active` will set the active Synergy Frame Link Module. `device_bays_ipv4_removed` will release the IPv4 address in the device bay. `interconnect_bays_ipv4_removed` will release the IPv4 address in the interconnect bay. `support_data_collection_set` will set the support data collection state for the enclosure. The supported values for this state are `PendingCollection`, `Completed`, `Error` and `NotSupported`  |
 
@@ -2191,8 +2149,6 @@ Manage OneView Enclosure resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -2205,16 +2161,15 @@ Retrieve facts about one or more Enclosures
 
 #### Requirements (on the host that executes the module)
   * hpOneView >= 2.0.1
-  * python >= 2.7.9
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   |  | |  Enclosure name.  |
 | options  |   |  | |  List with options to gather additional facts about an Enclosure and related resources. Options allowed: `script`, `environmentalConfiguration`, and `utilization`. For the option `utilization`, you can provide specific parameters.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -2319,8 +2274,6 @@ Retrieve facts about one or more Enclosures
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -2332,14 +2285,14 @@ Manage OneView Enclosure Group resources.
  Provides an interface to manage Enclosure Group resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Enclosure Group properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Enclosure Group resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 
@@ -2403,8 +2356,6 @@ Manage OneView Enclosure Group resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -2416,17 +2367,17 @@ Retrieve facts about one or more of the OneView Enclosure Groups.
  Retrieve facts about one or more of the Enclosure Groups from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Enclosure Group name.  |
 | options  |   No  |  | |  List with options to gather additional facts about Enclosure Group. Options allowed: `configuration_script` Gets the configuration script for an Enclosure Group.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -2483,8 +2434,6 @@ Retrieve facts about one or more of the OneView Enclosure Groups.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -2496,14 +2445,14 @@ Manage OneView Ethernet Network resources.
  Provides an interface to manage Ethernet Network resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Ethernet Network properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li>  <li>default_bandwidth_reset</li> </ul> |  Indicates the desired state for the Ethernet Network resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists. `default_bandwidth_reset` will reset the network connection template to the default.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -2603,8 +2552,6 @@ Manage OneView Ethernet Network resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -2616,17 +2563,17 @@ Retrieve the facts about one or more of the OneView Ethernet Networks.
  Retrieve the facts about one or more of the Ethernet Networks from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Ethernet Network name.  |
 | options  |   No  |  | |  List with options to gather additional facts about an Ethernet Network and related resources. Options allowed: `associatedProfiles` and `associatedUplinkGroups`.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -2691,8 +2638,6 @@ Retrieve the facts about one or more of the OneView Ethernet Networks.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -2704,14 +2649,14 @@ Manage OneView Events.
  Provides an interface to manage Events. Can only create.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.2.0
   * python >= 2.7.9
+  * hpOneView >= 3.2.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the Event properties.  |
 | state  |   |  | <ul> <li>present</li> </ul> |  Indicates the desired state for the Event. `present` will ensure data properties are compliant with OneView. This operation is non-idempotent.  |
 
@@ -2753,8 +2698,6 @@ Manage OneView Events.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -2766,16 +2709,16 @@ Retrieve the facts about one or more of the OneView Events.
  Retrieve the facts about one or more of the Events from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.2.0
   * python >= 2.7.9
+  * hpOneView >= 3.2.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Event name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -2819,8 +2762,6 @@ Retrieve the facts about one or more of the OneView Events.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -2832,14 +2773,14 @@ Manage OneView Fabric resources.
  Provides an interface for managing fabrics in OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Fabrics properties.  |
 | name  |   No  |  | |  Fabric name.  |
 
@@ -2880,8 +2821,6 @@ Manage OneView Fabric resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -2893,17 +2832,17 @@ Retrieve the facts about one or more of the OneView Fabrics.
  Retrieve the facts about one or more of the Fabrics from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Fabric name.  |
 | options  |   No  |  | |  List with options to gather additional facts about an Fabrics and related resources. Options allowed: `reservedVlanRange`.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -2964,8 +2903,6 @@ Retrieve the facts about one or more of the OneView Fabrics.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -2978,13 +2915,12 @@ Manage OneView Fibre Channel Network resources.
 
 #### Requirements (on the host that executes the module)
   * hpOneView >= 4.0.0
-  * python >= 2.7.9
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the Fibre Channel Network properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Fibre Channel Network resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -3046,8 +2982,6 @@ Manage OneView Fibre Channel Network resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3060,15 +2994,14 @@ Retrieve the facts about one or more of the OneView Fibre Channel Networks
 
 #### Requirements (on the host that executes the module)
   * hpOneView >= 2.0.1
-  * python >= 2.7.9
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   |  | |  Fibre Channel Network name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -3121,8 +3054,6 @@ Retrieve the facts about one or more of the OneView Fibre Channel Networks
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3134,14 +3065,14 @@ Manage OneView FCoE Network resources
  Provides an interface to manage FCoE Network resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with FCoE Network properties.  |
 | state  |   |  present  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the FCoE Network resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -3199,8 +3130,6 @@ Manage OneView FCoE Network resources
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3213,15 +3142,14 @@ Retrieve the facts about one or more of the OneView FCoE Networks
 
 #### Requirements (on the host that executes the module)
   * hpOneView >= 2.0.1
-  * python >= 2.7.9
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   |  | |  FCoE Network name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -3275,8 +3203,6 @@ Retrieve the facts about one or more of the OneView FCoE Networks
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3288,14 +3214,14 @@ Upload OneView Firmware Bundle resources.
  Upload an SPP ISO image file or a hotfix file to the appliance.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | file_path  |   Yes  |  | |  The full path of a local file to be loaded.  |
 | state  |   |  | <ul> <li>present</li> </ul> |  Indicates the desired state for the Firmware Driver resource. `present` will ensure that the firmware bundle is at OneView.  |
 
@@ -3333,8 +3259,6 @@ Upload OneView Firmware Bundle resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3346,14 +3270,14 @@ Provides an interface to remove Firmware Driver resources.
  Provides an interface to remove Firmware Driver resources.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   No  |  | |  List with the Firmware Driver properties.  |
 | name  |   No  |  | |  Firmware driver name.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Firmware Driver. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
@@ -3400,8 +3324,6 @@ Provides an interface to remove Firmware Driver resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3413,14 +3335,14 @@ Retrieve the facts about one or more of the OneView Firmware Drivers.
  Retrieve the facts about one or more of the Firmware Drivers from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Firmware driver name.  |
 | params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `sort`: The sort order of the returned data set.  |
 
@@ -3472,8 +3394,6 @@ Retrieve the facts about one or more of the OneView Firmware Drivers.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3485,14 +3405,14 @@ Manage OneView ID pools IPV4 Range resources.
  Provides an interface to manage ID pools IPV4 Range resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with ID pools IPV4 Range properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the ID pools IPV4 Range resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -3536,8 +3456,6 @@ Manage OneView ID pools IPV4 Range resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3549,17 +3467,17 @@ Retrieve the facts about one or more of the OneView ID Pools IPV4 Ranges.
  Retrieve the facts about one or more of the ID Pools IPV4 Ranges from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  ID Pools IPV4 Range name.  |
 | options  |   No  |  | |  List with options to gather additional facts about an IPv4 Range and related resources. Options allowed: `allocatedFragments` gets all fragments that have been allocated in range. `freeFragments` gets all free fragments in an IPv4 range.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 | uri  |   No  |  | |  ID Pools IPV4 Range ID or URI.  |
 
 
@@ -3633,8 +3551,6 @@ Retrieve the facts about one or more of the OneView ID Pools IPV4 Ranges.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3646,14 +3562,14 @@ Manage OneView ID pools IPV4 Subnet resources.
  Provides an interface to manage ID pools IPV4 Subnet resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with ID pools IPV4 Subnet properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the ID pools IPV4 Subnet resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -3698,8 +3614,6 @@ Manage OneView ID pools IPV4 Subnet resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3711,16 +3625,16 @@ Retrieve the facts about one or more of the OneView ID Pools IPV4 Subnets.
  Retrieve the facts about one or more of the ID Pools IPV4 Subnets from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  ID Pools IPV4 Subnet name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 | uri  |   No  |  | |  ID Pools IPV4 Subnet ID or URI.  |
 
 
@@ -3770,8 +3684,6 @@ Retrieve the facts about one or more of the OneView ID Pools IPV4 Subnets.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3783,14 +3695,14 @@ Manage the OneView Interconnect resources.
  Provides an interface to manage Interconnect resources. Can change the power state, UID light state, perform device reset, reset port protection, and update the interconnect ports.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.3.0
   * python >= 2.7.9
+  * hpOneView >= 3.3.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | ip  |   No  |  | |  Interconnect IP address.  |
 | name  |   No  |  | |  Interconnect name.  |
 | ports  |   No  |  | |  List with ports to update. This option should be used together with `update_ports` state.  |
@@ -3845,8 +3757,6 @@ Manage the OneView Interconnect resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -3858,17 +3768,17 @@ Retrieve facts about one or more of the OneView Interconnects.
  Retrieve facts about one or more of the Interconnects from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.3.0
   * python >= 2.7.9
+  * hpOneView >= 3.3.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Interconnect name.  |
 | options  |   No  |  | |  List with options to gather additional facts about Interconnect. Options allowed: `nameServers` gets the named servers for an interconnect. `statistics` gets the statistics from an interconnect. `portStatistics` gets the statistics for the specified port name on an interconnect. `subPortStatistics` gets the subport statistics on an interconnect. `ports` gets all interconnect ports. `port` gets a specific interconnect port. `pluggableModuleInformation` gets all the SFP information.  To gather additional facts it is required inform the Interconnect name. Otherwise, these options will be ignored.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -4000,8 +3910,6 @@ Retrieve facts about one or more of the OneView Interconnects.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -4013,16 +3921,16 @@ Retrieve facts about the OneView Interconnect Link Topologies.
  Retrieve facts about the Interconnect Link Topologies from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of the Interconnect Link Topology.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -4075,8 +3983,6 @@ Retrieve facts about the OneView Interconnect Link Topologies.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -4088,16 +3994,16 @@ Retrieve facts about one or more of the OneView Interconnect Types.
  Retrieve facts about one or more of the Interconnect Types from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Interconnect Type name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -4148,8 +4054,6 @@ Retrieve facts about one or more of the OneView Interconnect Types.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -4161,14 +4065,14 @@ Retrieve facts about the OneView Internal Link Sets.
  Retrieve facts about the Internal Link Sets from OneView. It is possible get all Internal Link Sets or filter by name.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of the Internal Link Set.  |
 | params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set. `query`: A general query string to narrow the list of resources returned. `fields`: Specifies which fields should be returned in the result set. `view`: Return a specific subset of the attributes of the resource or collection, by specifying the name of a predefined view.  |
 
@@ -4222,8 +4126,6 @@ Retrieve facts about the OneView Internal Link Sets.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -4235,17 +4137,17 @@ Retrieve facts about one or more of the OneView Logical Downlinks.
  Retrieve facts about one or more of the Logical Downlinks from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | excludeEthernet  |   No  |  | |  Excludes any facts about Ethernet networks from the Logical Downlinks.  |
 | name  |   No  |  | |  Logical Downlink name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -4307,8 +4209,6 @@ Retrieve facts about one or more of the OneView Logical Downlinks.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -4320,14 +4220,14 @@ Manage OneView Logical Enclosure resources.
  Provides an interface to manage Logical Enclosure resources. Can create, update, update firmware, perform dump, update configuration script, reapply configuration, update from group, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Logical Enclosure properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>firmware_updated</li>  <li>script_updated</li>  <li>dumped</li>  <li>reconfigured</li>  <li>updated_from_group</li>  <li>absent</li> </ul> |  Indicates the desired state for the Logical Enclosure resource. `present` ensures data properties are compliant with OneView. You can rename the enclosure providing an attribute `newName`. `firmware_updated` updates the firmware for the Logical Enclosure. `script_updated` updates the Logical Enclosure configuration script. `dumped` generates a support dump for the Logical Enclosure. `reconfigured` reconfigures all enclosures associated with a logical enclosure. `updated_from_group` makes the logical enclosure consistent with the enclosure group. `absent` will remove the resource from OneView, if it exists.  |
 
@@ -4455,8 +4355,6 @@ Manage OneView Logical Enclosure resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -4468,17 +4366,17 @@ Retrieve facts about one or more of the OneView Logical Enclosures.
  Retrieve facts about one or more of the Logical Enclosures from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Logical Enclosure name.  |
 | options  |   No  |  | |  List with options to gather additional facts about a Logical Enclosure and related resources. Options allowed: script.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -4543,8 +4441,6 @@ Retrieve facts about one or more of the OneView Logical Enclosures.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -4556,14 +4452,14 @@ Manage OneView Logical Interconnect resources.
  Provides an interface to manage Logical Interconnect resources.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the options.  |
 | state  |   |  | <ul> <li>compliant</li>  <li>ethernet_settings_updated</li>  <li>internal_networks_updated</li>  <li>settings_updated</li>  <li>forwarding_information_base_generated</li>  <li>qos_aggregated_configuration_updated</li>  <li>snmp_configuration_updated</li>  <li>port_monitor_updated</li>  <li>configuration_updated</li>  <li>firmware_installed</li>  <li>telemetry_configuration_updated</li> </ul> |  Indicates the desired state for the Logical Interconnect resource. `compliant` brings the logical interconnect back to a consistent state. `ethernet_settings_updated` updates the Ethernet interconnect settings for the logical interconnect. `internal_networks_updated` updates the internal networks on the logical interconnect. This operation is non-idempotent. `settings_updated` updates the Logical Interconnect settings. `forwarding_information_base_generated` generates the forwarding information base dump file for the logical interconnect. This operation is non-idempotent and asynchronous. `qos_aggregated_configuration_updated` updates the QoS aggregated configuration for the logical interconnect. `snmp_configuration_updated` updates the SNMP configuration for the logical interconnect. `port_monitor_updated` updates the port monitor configuration of a logical interconnect. `configuration_updated` asynchronously applies or re-applies the logical interconnect configuration to all managed interconnects. This operation is non-idempotent. `firmware_installed` installs firmware to a logical interconnect. The three operations that are supported for the firmware update are Stage (uploads firmware to the interconnect), Activate (installs firmware on the interconnect) and Update (which does a Stage and Activate in a sequential manner). All of them are non-idempotent. `telemetry_configuration_updated` updates the telemetry configuration of a logical interconnect. `scopes_updated` updates the scopes associated with the logical interconnect.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -4718,8 +4614,6 @@ Manage OneView Logical Interconnect resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -4731,17 +4625,17 @@ Retrieve facts about one or more of the OneView Logical Interconnects.
  Retrieve facts about one or more of the OneView Logical Interconnects.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.1
   * python >= 2.7.9
+  * hpOneView >= 3.1.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Logical Interconnect name.  |
 | options  |   No  |  | |  List with options to gather additional facts about Logical Interconnect. Options allowed: `qos_aggregated_configuration` gets the QoS aggregated configuration for the logical interconnect. `snmp_configuration` gets the SNMP configuration for a logical interconnect. `port_monitor` gets the port monitor configuration of a logical interconnect. `internal_vlans` gets the internal VLAN IDs for the provisioned networks on a logical interconnect. `forwarding_information_base` gets the forwarding information base data for a logical interconnect. `firmware` get the installed firmware for a logical interconnect. `unassigned_uplink_ports` gets a collection of uplink ports from the member interconnects which are eligible for assignment to an analyzer port. `telemetry_configuration` gets the telemetry configuration of the logical interconnect. `ethernet_settings` gets the Ethernet interconnect settings for the Logical Interconnect. - These options are valid just when a `name` is provided. Otherwise it will be ignored.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -4829,8 +4723,6 @@ Retrieve facts about one or more of the OneView Logical Interconnects.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -4842,14 +4734,14 @@ Manage OneView Logical Interconnect Group resources.
  Provides an interface to manage Logical Interconnect Group resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the Logical Interconnect Group properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Logical Interconnect Group resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -4924,8 +4816,6 @@ Manage OneView Logical Interconnect Group resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -4938,15 +4828,14 @@ Retrieve facts about one or more of the OneView Logical Interconnect Groups
 
 #### Requirements (on the host that executes the module)
   * hpOneView >= 2.0.1
-  * python >= 2.7.9
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   |  | |  Logical Interconnect Group name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -5012,8 +4901,6 @@ Retrieve facts about one or more of the OneView Logical Interconnect Groups
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -5025,14 +4912,14 @@ Manage OneView Logical Switch resources.
  Provides an interface to manage Logical Switch resources. Can create, update, delete, or refresh.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the Logical Switches properties. You can choose set the Logical Switch Group by `logicalSwitchGroupName` or `logicalSwitchGroupUri`.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>updated</li>  <li>absent</li>  <li>refreshed</li> </ul> |  Indicates the desired state for the Logical Switch resource. `present` creates a Logical Switch, if it doesn't exist. To update the Logical Switch, use the `updated` state instead. `updated` ensures the Logical Switch is updated. Currently OneView only supports updating the credentials , scopes and name of the Logical Switch. To change the name of the Logical Switch, a `newName` in the data must be provided. The update operation is non-idempotent. `absent` removes the resource from OneView, if it exists. `refreshed` reclaims the top-of-rack switches in the logical switch. This operation is non-idempotent.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -5152,8 +5039,6 @@ Manage OneView Logical Switch resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -5165,16 +5050,16 @@ Retrieve the facts about one or more of the OneView Logical Switches.
  Retrieve the facts about one or more of the Logical Switches from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Logical Switch name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -5227,8 +5112,6 @@ Retrieve the facts about one or more of the OneView Logical Switches.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -5240,14 +5123,14 @@ Manage OneView Logical Switch Group resources.
  Provides an interface to manage Logical Switch Group resources. Can add, update, remove.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Logical Switch Group properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Logical Switch Group resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -5323,8 +5206,6 @@ Manage OneView Logical Switch Group resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -5336,16 +5217,16 @@ Retrieve facts about OneView Logical Switch Groups.
  Retrieve facts about the Logical Switch Groups of the OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Logical Switch Group name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -5400,8 +5281,6 @@ Retrieve facts about OneView Logical Switch Groups.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -5413,14 +5292,14 @@ Manage OneView Managed SAN resources.
  Provides an interface to manage Managed SAN resources. Can update the Managed SAN, set the refresh state, create a SAN endpoints CSV file, and create an unexpected zoning issue report.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Managed SAN properties and its associated states. Warning: For the 'present' state, the contents of the publicAttributes will replace the existing list, so leaving out a public attribute from the given list will effectively delete it.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>refresh_state_set</li>  <li>endpoints_csv_file_created</li>  <li>issues_report_created</li> </ul> |  Indicates the desired state for the Managed SAN resource. `present` ensures data properties are compliant with OneView. `refresh_state_set` updates the refresh state of the Managed SAN. `endpoints_csv_file_created` creates a SAN endpoints CSV file. `issues_report_created` creates an unexpected zoning report for a SAN.  |
 
@@ -5497,8 +5376,6 @@ Manage OneView Managed SAN resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -5510,14 +5387,14 @@ Retrieve facts about the OneView Managed SANs.
  Retrieve facts about the OneView Managed SANs.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of the Managed SAN.  |
 | options  |   No  |  | |  List with options to gather additional facts about Managed SAN. Options allowed: `endpoints` gets the list of endpoints in the SAN identified by name. `wwn` gets the list of Managed SANs associated with an informed WWN `locate`.  |
 | params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `query`: A general query string to narrow the list of resources returned. `sort`: The sort order of the returned data set.  |
@@ -5597,8 +5474,6 @@ Retrieve facts about the OneView Managed SANs.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -5610,14 +5485,14 @@ Manage OneView Network Set resources.
  Provides an interface to manage Network Set resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the Network Set properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Network Set resource. `present` ensures data properties are compliant with OneView. `absent` removes the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -5685,8 +5560,6 @@ Manage OneView Network Set resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -5699,16 +5572,15 @@ Retrieve facts about the OneView Network Sets
 
 #### Requirements (on the host that executes the module)
   * hpOneView >= 2.0.1
-  * python >= 2.7.9
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   |  | |  Network Set name.  |
 | options  |   |  | |  List with options to gather facts about Network Set. Option allowed: `withoutEthernet`. The option `withoutEthernet` retrieves the list of network_sets excluding Ethernet networks.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -5803,8 +5675,6 @@ Retrieve facts about the OneView Network Sets
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -5816,17 +5686,17 @@ Retrieve facts about one or more Os Deployment Plans.
  Retrieve facts about one or more of the Os Deployment Plans from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Os Deployment Plan name.  |
 | options  |   No  |  | |  List with options to gather facts about OS Deployment Plan. Option allowed: `osCustomAttributesForServerProfile` The option `osCustomAttributesForServerProfile` retrieves the list of editable OS Custom Atributes, prepared for Server Profile use.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -5889,8 +5759,6 @@ Retrieve facts about one or more Os Deployment Plans.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -5902,14 +5770,14 @@ Manage OneView Deployment Server resources.
  Provides an interface to manage Deployment Server resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.1
   * python >= 2.7.9
+  * hpOneView >= 3.1.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Deployment Server properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Deployment Server resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -5970,8 +5838,6 @@ Manage OneView Deployment Server resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -5983,14 +5849,14 @@ Retrieve facts about one or more OS Deployment Servers.
  Retrieve facts about one or more of the OS Deployment Servers from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.1
   * python >= 2.7.9
+  * hpOneView >= 3.1.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  OS Deployment Server name.  |
 | options  |   No  |  | |  List with options to gather additional facts about an OS Deployment Server and related resources. Options allowed: `networks`, `appliances`, and `appliance`.  |
 | params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set. `query`: A general query string to narrow the list of resources returned. `fields`: Specifies which fields should be returned in the result set. `view`: Return a specific subset of the attributes of the resource or collection, by specifying the name of a predefined view.  |
@@ -6054,8 +5920,6 @@ Retrieve facts about one or more OS Deployment Servers.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -6067,14 +5931,14 @@ Manage OneView Power Device resources.
  Provides an interface to manage Power delivery devices resources. Can add, update, remove, change power state, change UID state and refresh state.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Power Device properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>discovered</li>  <li>absent</li>  <li>power_state_set</li>  <li>refresh_state_set</li>  <li>uid_state_set</li> </ul> |  Indicates the desired state for the Power Device resource. `present` will ensure data properties are compliant with OneView. `discovered` will add an iPDU to the OneView. `absent` will remove the resource from OneView, if it exists. `power_state_set` will set the power state of the Power Device. `refresh_state_set` will set the refresh state of the Power Device. `uid_state_set` will set the UID state of the Power Device.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -6162,8 +6026,6 @@ Manage OneView Power Device resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -6175,14 +6037,14 @@ Retrieve facts about the OneView Power Devices.
  Retrieve facts about the Power Delivery Devices from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Power Device name.  |
 | options  |   No  |  | |  List with options to gather additional facts about Power Device. Options allowed: `powerState`, `uidState`, `utilization`  |
 | params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `query`: A general query string to narrow the list of resources returned. `sort`: The sort order of the returned data set.  |
@@ -6268,8 +6130,6 @@ Retrieve facts about the OneView Power Devices.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -6281,14 +6141,14 @@ Manage OneView Racks resources.
  Provides an interface to manage Rack resources. Can create, update, and delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the Rack properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Rack resource. `present` will ensure data properties are compliant with OneView. To change the name of the Rack, a _newName_ in the data must be provided. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -6354,8 +6214,6 @@ Manage OneView Racks resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -6367,17 +6225,17 @@ Retrieve facts about Rack resources.
  Gets a list of rack resources. Filter by name can be used to get a specific Rack. If a name is specified, it is  allowed to retrieve information about the device topology.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Rack name.  |
 | options  |   No  |  | |  Retrieve additional facts. Options available: 'deviceTopology'.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -6437,8 +6295,6 @@ Retrieve facts about Rack resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -6450,14 +6306,14 @@ Manage OneView SAN Manager resources.
  Provides an interface to manage SAN Manager resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.1
   * python >= 2.7.9
+  * hpOneView >= 3.1.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with SAN Manager properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li>  <li>connection_information_set</li> </ul> |  Indicates the desired state for the Uplink Set resource. `present` ensures data properties are compliant with OneView. `absent` removes the resource from OneView, if it exists. `connection_information_set` updates the connection information for the SAN Manager. This operation is non-idempotent.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -6537,8 +6393,6 @@ Manage OneView SAN Manager resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -6551,13 +6405,12 @@ Retrieve facts about one or more of the OneView SAN Managers
 
 #### Requirements (on the host that executes the module)
   * hpOneView >= 2.0.1
-  * python >= 2.7.9
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `query`: A general query string to narrow the list of resources returned. - `sort`: The sort order of the returned data set.  |
 | provider_display_name  |   |  | |  Provider Display Name.  |
 
@@ -6613,8 +6466,6 @@ Retrieve facts about one or more of the OneView SAN Managers
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -6626,14 +6477,14 @@ Manage the OneView SAS Interconnect resources.
  Provides an interface to manage the SAS Interconnect. Can change the power state, UID light state, perform soft and hard reset, and refresh the SAS Interconnect state.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   Yes  |  | |  The SAS Interconnect name.  |
 | state  |   |  | <ul> <li>powered_on</li>  <li>powered_off</li>  <li>uid_on</li>  <li>uid_off</li>  <li>soft_reset</li>  <li>hard_reset</li>  <li>refreshed</li> </ul> |  Indicates the desired state for the Switch. `powered_on` turns the power on. `powered_off` turns the power off. `uid_on` turns the UID light on. `uid_off` turns the UID light off. `soft_reset` performs a soft reset. `hard_reset` performs a hard reset. `refreshed` performs a refresh.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -6676,8 +6527,6 @@ Manage the OneView SAS Interconnect resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -6689,16 +6538,16 @@ Retrieve facts about the OneView SAS Interconnects.
  Retrieve facts about the OneView SAS Interconnects.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  SAS Interconnect name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -6745,8 +6594,6 @@ Retrieve facts about the OneView SAS Interconnects.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -6758,16 +6605,16 @@ Retrieve facts about the OneView SAS Interconnect Types.
  Retrieve facts about the SAS Interconnect Types from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of the SAS Interconnect Type.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -6820,8 +6667,6 @@ Retrieve facts about the OneView SAS Interconnect Types.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -6833,14 +6678,14 @@ Manage OneView SAS Logical Interconnect resources.
  Provides an interface to manage SAS Logical Interconnect resources.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with SAS Logical Interconnect properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>compliant</li>  <li>drive_enclosure_replaced</li>  <li>configuration_updated</li>  <li>firmware_updated</li> </ul> |  Indicates the desired state for the SAS Logical Interconnect resources. `compliant` brings the list of SAS Logical Interconnect back to a consistent state. `configuration_updated` asynchronously applies or re-applies the SAS Logical Interconnect configuration to all managed interconnects. `firmware_updated` installs firmware to a SAS Logical Interconnect. `drive_enclosure_replaced` replacement operation of a drive enclosure. * All of them are non-idempotent.  |
 
@@ -6922,8 +6767,6 @@ Manage OneView SAS Logical Interconnect resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -6935,17 +6778,17 @@ Retrieve facts about one or more of the OneView SAS Logical Interconnects.
  Retrieve facts about one or more of the OneView SAS Logical Interconnects.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  SAS Logical Interconnect name.  |
 | options  |   No  |  | |  List with options to gather additional facts about SAS Logical Interconnect. `firmware` gets the installed firmware for a SAS Logical Interconnect.  These options are valid just when a `name` is provided. Otherwise it will be ignored.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -7007,8 +6850,6 @@ Retrieve facts about one or more of the OneView SAS Logical Interconnects.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -7020,14 +6861,14 @@ Manage OneView SAS Logical Interconnect Group resources.
  Provides an interface to manage SAS Logical Interconnect Group resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the SAS Logical Interconnect Group properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the SAS Logical Interconnect Group resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -7103,8 +6944,6 @@ Manage OneView SAS Logical Interconnect Group resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -7116,16 +6955,16 @@ Retrieve facts about one or more of the OneView SAS Logical Interconnect Groups.
  Retrieve facts about one or more of the SAS Logical Interconnect Groups from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0
   * python >= 2.7.9
+  * hpOneView >= 3.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of the SAS Logical Interconnect Group.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -7175,8 +7014,6 @@ Retrieve facts about one or more of the OneView SAS Logical Interconnect Groups.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -7188,16 +7025,16 @@ Retrieve facts about one or more of the OneView SAS Logical JBOD Attachments.
  Retrieve facts about one or more of the SAS Logical JBOD Attachments from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0
   * python >= 2.7.9
+  * hpOneView >= 3.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of SAS Logical JBOD Attachment.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -7251,8 +7088,6 @@ Retrieve facts about one or more of the OneView SAS Logical JBOD Attachments.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -7264,17 +7099,17 @@ Retrieve facts about one or more of the OneView SAS Logical JBODs.
  Retrieve facts about one or more of the SAS Logical JBODs from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of SAS Logical JBODs.  |
 | options  |   No  |  | |  List with options to gather additional facts about SAS Logical JBODs and related resources. Options allowed: `drives`.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -7338,8 +7173,6 @@ Retrieve facts about one or more of the OneView SAS Logical JBODs.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -7351,14 +7184,14 @@ Manage OneView Scope resources.
  Provides an interface to manage scopes. Can create, update, or delete scopes, and modify the scope membership by adding or removing resource assignments.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the Scopes properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li>  <li>resource_assignments_updated</li> </ul> |  Indicates the desired state for the Scope resource. `present` ensures data properties are compliant with OneView. `absent` removes the resource from OneView, if it exists. `resource_assignments_updated` modifies scope membership by adding or removing resource assignments. This operation is non-idempotent.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -7440,8 +7273,6 @@ Manage OneView Scope resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -7453,8 +7284,8 @@ Retrieve facts about one or more of the OneView Scopes.
  Retrieve facts about one or more of the Scopes from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
@@ -7516,8 +7347,6 @@ Retrieve facts about one or more of the OneView Scopes.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -7529,14 +7358,14 @@ Manage OneView Server Hardware resources.
  Provides an interface to manage Server Hardware resources.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.0.0
   * python >= 2.7.9
+  * hpOneView >= 3.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Server Hardware properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li>  <li>power_state_set</li>  <li>refresh_state_set</li>  <li>ilo_firmware_version_updated</li>  <li>ilo_state_reset</li>  <li>uid_state_on</li>  <li>uid_state_off</li>  <li>environmental_configuration_set</li> </ul> |  Indicates the desired state for the Server Hardware resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists. `power_state_set` will set the power state of the Server Hardware. `refresh_state_set` will set the refresh state of the Server Hardware. `ilo_firmware_version_updated` will update the iLO firmware version of the Server Hardware. `ilo_state_reset` will reset the iLO state. `uid_state_on` will set on the UID state, if necessary. `uid_state_off` will set off the UID state, if necessary. `environmental_configuration_set` will set the environmental configuration of the Server Hardware.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -7644,8 +7473,6 @@ Manage OneView Server Hardware resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -7657,17 +7484,17 @@ Retrieve facts about the OneView Server Hardwares.
  Retrieve facts about the Server Hardware from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Server Hardware name.  |
 | options  |   No  |  | |  List with options to gather additional facts about Server Hardware related resources. Options allowed: `bios`, `javaRemoteConsoleUrl`, `environmentalConfig`, `iloSsoUrl`, `remoteConsoleUrl`, `utilization`, `firmware`, `firmwares` and `physicalServerHardware`.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -7787,8 +7614,6 @@ Retrieve facts about the OneView Server Hardwares.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -7800,14 +7625,14 @@ Manage OneView Server Hardware Type resources.
  Provides an interface to manage Server Hardware Type resources. Can update, and remove.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Server Hardware Type properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Server Hardware Type resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -7863,8 +7688,6 @@ Manage OneView Server Hardware Type resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -7876,16 +7699,16 @@ Retrieve facts about Server Hardware Types of the OneView.
  Retrieve facts about Server Hardware Types of the OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Server Hardware Type name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -7936,8 +7759,6 @@ Retrieve facts about Server Hardware Types of the OneView.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -7950,14 +7771,13 @@ Manage OneView Server Profile resources
 
 #### Requirements (on the host that executes the module)
   * hpOneView >= 4.0.0
-  * python >= 2.7.9
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
 | auto_assign_server_hardware  |   |  True  | <ul> <li>True</li>  <li>False</li> </ul> |  Bool indicating whether or not a Server Hardware should be automatically retrieved and assigned to the Server Profile. When set to true, creates and updates try to ensure that an available Server Hardware is assigned to the Server Profile. When set to false, if no Server Hardware is specified during creation, the profile is created as 'unassigned'. If the profile already has a Server Hardware assigned to it and a serverHardwareName or serverHardwareUri is specified as None, the Server Profile will have its Server Hardware unassigned.  |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Server Profile properties.  |
 | state  |   |  present  | <ul> <li>present</li>  <li>absent</li>  <li>compliant</li> </ul> |  Indicates the desired state for the Server Profile resource by the end of the playbook execution. `present` will ensure data properties are compliant with OneView. This operation will power off the Server Hardware before configuring the Server Profile. After it completes, the Server Hardware is powered on. `absent` will remove the resource from OneView, if it exists. `compliant` will make the server profile compliant with its server profile template, when this option was specified. If there are Offline updates, the Server Hardware is turned off before remediate compliance issues and turned on after that.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -8086,8 +7906,6 @@ Manage OneView Server Profile resources
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -8099,17 +7917,17 @@ Retrieve facts about the OneView Server Profiles.
  Retrieve facts about the Server Profile from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   |  | |  Server Profile name.  |
 | options  |   |  | |  List with options to gather additional facts about Server Profile related resources. Options allowed: `schema`, `compliancePreview`, `profilePorts`, `messages`, `transformation`, `available_networks`, `available_servers`, `available_storage_system`, `available_storage_systems`, `available_targets`, `newProfileTemplate`,  To gather facts about `compliancePreview`, `messages`, `newProfileTemplate` and `transformation` a Server Profile name is required. Otherwise, these options will be ignored.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 | uri  |   |  | |  Server Profile uri.  |
 
 
@@ -8240,8 +8058,6 @@ Retrieve facts about the OneView Server Profiles.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -8253,14 +8069,14 @@ Manage OneView Server Profile Template resources.
  Provides an interface to create, modify, and delete server profile templates.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  Dict with Server Profile Template properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Server Profile Template. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -8322,8 +8138,6 @@ Manage OneView Server Profile Template resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -8335,17 +8149,17 @@ Retrieve facts about the Server Profile Templates from OneView.
  Retrieve facts about the Server Profile Templates from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   |  | |  Server Profile Template name.  |
 | options  |   |  | |  List with options to gather additional facts about Server Profile Template resources. Options allowed: `new_profile` and `transformation`.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 | uri  |   |  | |  Server Profile Template uri.  |
 
 
@@ -8412,8 +8226,6 @@ Retrieve facts about the Server Profile Templates from OneView.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -8425,14 +8237,14 @@ Manage OneView Storage Pool resources.
  Provides an interface to manage Storage Pool resources. Can add and remove.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Storage Pool properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Storage Pool resource. `present` will ensure data properties are compliant with OneView. From API500 onwards it is only possible to update its state. `absent` will remove the resource from OneView, if it exists. From API500 onwards absent state is immutable.  |
 
@@ -8498,8 +8310,6 @@ Manage OneView Storage Pool resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -8511,17 +8321,17 @@ Retrieve facts about one or more Storage Pools.
  Retrieve facts about one or more of the Storage Pools from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Storage Pool name.  |
 | options  |   No  |  | |  List with options to gather additional facts about Storage Pools. Options allowed: `reachableStoragePools` gets the list of reachable Storage pools based on the network param. If the network param is not specified it gets all of them.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -8590,8 +8400,6 @@ Retrieve facts about one or more Storage Pools.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -8603,14 +8411,14 @@ Manage OneView Storage System resources.
  Provides an interface to manage Storage System resources. Can add, update and remove.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Storage System properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Storage System resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -8696,8 +8504,6 @@ Manage OneView Storage System resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -8709,17 +8515,17 @@ Retrieve facts about the OneView Storage Systems
  Retrieve facts about the Storage Systems from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   |  | |  Storage System name.  |
 | options  |   |  | |  List with options to gather additional facts about a Storage System and related resources. Options allowed: `hostTypes` gets the list of supported host types. `storagePools` gets a list of storage pools belonging to the specified storage system. `reachablePorts` gets a list of storage system reachable ports. Accepts `params`. An additional `networks` list param can be used to restrict the search for only these ones. `templates` gets a list of storage templates belonging to the storage system.  To gather facts about `storagePools`, `reachablePorts`, and `templates` it is required to inform either the argument `name`, `ip_hostname`, or `hostname`. Otherwise, this option will be ignored.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 | storage_hostname  |   |  | |  Storage System IP or hostname.  |
 
 
@@ -8832,8 +8638,6 @@ Retrieve facts about the OneView Storage Systems
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -8845,14 +8649,14 @@ Provides an interface to remove extra presentations from a specified server prof
  Provides an interface to remove extra presentations from a specified server profile.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | server_profile  |   Yes  |  | |  Server Profile name or Server Profile URI  |
 | state  |   Yes  |  | <ul> <li>extra_presentations_removed</li> </ul> |  Indicates the desired state for the Storage Volume Attachment `extra_presentations_removed` will remove extra presentations from a specified server profile.  |
 
@@ -8900,8 +8704,6 @@ Provides an interface to remove extra presentations from a specified server prof
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -8913,16 +8715,16 @@ Retrieve facts about the OneView Storage Volume Attachments.
  Retrieve facts about the OneView Storage Volume Attachments. To gather facts about a specific Storage Volume Attachment it is required to inform the option _storageVolumeAttachmentUri_. It is also possible to retrieve a specific Storage Volume Attachment by the Server Profile and the Volume. For this option, it is required to inform the option _serverProfileName_ and the param _storageVolumeName_ or _storageVolumeUri_.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | options  |   No  |  | |  Retrieve additional facts. Options available: `extraUnmanagedStorageVolumes` retrieve the list of extra unmanaged storage volumes. `paths` retrieve all paths or a specific attachment path for the specified volume attachment. To retrieve a specific path a `pathUri` or a `pathId` must be informed  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 | serverProfileName  |   No  |  | |  Server Profile name.  |
 | storageVolumeAttachmentUri  |   No  |  | |  Storage Volume Attachment uri.  |
 | storageVolumeName  |   No  |  | |  Storage Volume name.  |
@@ -9025,8 +8827,6 @@ Retrieve facts about the OneView Storage Volume Attachments.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9038,14 +8838,14 @@ Manage OneView Storage Volume Template resources.
  Provides an interface to manage Storage Volume Template resources. Can create, update and delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Storage Volume Template properties and its associated states.  |
 | state  |   Yes  |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Storage Volume Template resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -9103,8 +8903,6 @@ Manage OneView Storage Volume Template resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9116,17 +8914,17 @@ Retrieve facts about Storage Volume Templates of the OneView.
  Retrieve facts about Storage Volume Templates of the OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Storage Volume Template name.  |
 | options  |   No  |  | |  Retrieve additional facts. Options available: `connectableVolumeTemplates`, `reachableVolumeTemplates`, `compatibleSystems`  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -9209,8 +9007,6 @@ Retrieve facts about Storage Volume Templates of the OneView.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9222,14 +9018,14 @@ Provides an interface to remove ToR Switch resources.
  Provides an interface to remove Top of Rack(ToR) Switch resources. The switch resource will be removed if it is in an unmanaged state. If the switch resource is associated with a Logical Switch, it's removal is treated as a hardware removal only. A reference to the switch is mantained, and the resource is marked as 'Absent'.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   Yes  |  | |  Switch name.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li>  <li>ports_updated</li> </ul> |  Indicates the desired state for the Switch resource. `present` will update the switch scopes, if they differ from what is declared. `absent` will remove the resource from OneView, if it exists. `ports_updated` will update the switch ports.  |
 
@@ -9259,8 +9055,6 @@ Provides an interface to remove ToR Switch resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9272,17 +9066,17 @@ Retrieve facts about the OneView Switches.
  Retrieve facts about the OneView Switches.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Switch name.  |
 | options  |   No  |  | |  List with options to gather additional facts about the Switch. Options allowed: `environmentalConfiguration` gets the environmental configuration for a switch.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -9337,8 +9131,6 @@ Retrieve facts about the OneView Switches.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9350,16 +9142,16 @@ Retrieve facts about the OneView Switch Types.
  Retrieve facts about the Switch Types from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Name of the Switch Type.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -9410,8 +9202,6 @@ Retrieve facts about the OneView Switch Types.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9423,14 +9213,14 @@ Retrieve facts about the OneView Tasks.
  Retrieve facts about the OneView Tasks.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | params  |   No  |  | |  List with parameters to help filter the tasks. Params allowed: `count`, `fields`, `filter`, `query`, `sort`, `start`, and `view`.  |
 
 
@@ -9475,8 +9265,6 @@ Retrieve facts about the OneView Tasks.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9488,14 +9276,14 @@ Manage OneView Unmanaged Device resources.
  Provides an interface to manage Unmanaged Device resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Unmanaged Device properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Unmanaged Device resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -9575,8 +9363,6 @@ Manage OneView Unmanaged Device resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9588,17 +9374,17 @@ Retrieve facts about one or more of the OneView Unmanaged Device.
  Retrieve facts about one or more of the Unmanaged Device from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Unmanaged Device name.  |
 | options  |   |  | |  List with options to gather additional facts about the Unmanaged Device. Options allowed: `environmental_configuration` gets a description of the environmental configuration for the Unmnaged Device.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -9659,8 +9445,6 @@ Retrieve facts about one or more of the OneView Unmanaged Device.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9672,14 +9456,14 @@ Manage OneView Uplink Set resources.
  Provides an interface to manage Uplink Set resources. Can create, update, or delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.1.0
   * python >= 2.7.9
+  * hpOneView >= 3.1.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with Uplink Set properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li> </ul> |  Indicates the desired state for the Uplink Set resource. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists. The key used to find the resource to perform the operation is a compound key, that consists of the name of the uplink set and the URI (or name) of the Logical Interconnect combined. You can choose to set the Logical Interconnect by logicalInterconnectUri or logicalInterconnectName.  |
 | validate_etag  |   |  True  | <ul> <li>true</li>  <li>false</li> </ul> |  When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag for the resource matches the ETag provided in the data.  |
@@ -9749,8 +9533,6 @@ Manage OneView Uplink Set resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9762,16 +9544,16 @@ Retrieve facts about one or more of the OneView Uplink Sets.
  Retrieve facts about one or more of the Uplink Sets from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Uplink Set name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -9822,8 +9604,6 @@ Retrieve facts about one or more of the OneView Uplink Sets.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9835,14 +9615,14 @@ Manage OneView Users.
  Provides an interface to manage Users. Can create, update, and delete.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.2.0
   * python >= 2.7.9
+  * hpOneView >= 3.2.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  List with the User properties.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li>  <li>set_password</li> </ul> |  Indicates the desired state for the User. `present` will ensure data properties are compliant with OneView. `absent` will remove the resource from OneView, if it exists. `set_password` will set a user password to the value specified. This operation is non-idempotent.  |
 
@@ -9909,8 +9689,6 @@ Manage OneView Users.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9922,16 +9700,16 @@ Retrieve the facts about one or more of the OneView Users.
  Retrieve the facts about one or more of the Users from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 3.2.0
   * python >= 2.7.9
+  * hpOneView >= 3.2.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  User name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -9982,8 +9760,6 @@ Retrieve the facts about one or more of the OneView Users.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -9995,14 +9771,14 @@ Manage OneView Volume resources.
  Provides an interface to manage Volume resources. It allows create, update, delete or repair the volume, and create or delete a snapshot.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 4.0.0
   * python >= 2.7.9
+  * hpOneView >= 4.0.0
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | data  |   Yes  |  | |  Volume or snapshot data.  |
 | export_only  |   |  False  | |  If set to True, when the status is `absent` and the resource exists, it will be removed only from OneView.  |
 | state  |   |  | <ul> <li>present</li>  <li>absent</li>  <li>repaired</li>  <li>snapshot_created</li>  <li>snapshot_deleted</li> </ul> |  Indicates the desired state for the Volume resource. `present` creates/adds the resource when it does not exist, otherwise it updates the resource. When the resource already exists, the update operation is non-convergent, since it is always called even though the given options are compliant with the existent data. To change the name of the volume, a `newName` in the _data_ must be provided. `absent` by default deletes a volume from OneView and the storage system. When export_only is True, the volume is removed only from OneView. `repaired` removes extra presentations from a specified volume on the storage system. This operation is non-idempotent. `snapshot_created` creates a snapshot for the volume specified. This operation is non-idempotent. `snapshot_deleted` deletes a snapshot from OneView and the storage system.  |
@@ -10136,8 +9912,6 @@ Manage OneView Volume resources.
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
 
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
-
 
 ---
 
@@ -10149,17 +9923,17 @@ Retrieve facts about the OneView Volumes.
  Retrieve facts about the Volumes from OneView.
 
 #### Requirements (on the host that executes the module)
-  * hpOneView >= 2.0.1
   * python >= 2.7.9
+  * hpOneView >= 2.0.1
 
 #### Options
 
 | Parameter     | Required    | Default  | Choices    | Comments |
 | ------------- |-------------| ---------|----------- |--------- |
-| config  |   |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional and when used should be present in the host running the ansible commands. If the file path is not provided, the configuration will be loaded from environment variables. For links to example configuration files or how to use the environment variables verify the notes section.  |
+| config  |   No  |  | |  Path to a .json configuration file containing the OneView client configuration. The configuration file is optional. If the file path is not provided, the configuration will be loaded from environment variables.  |
 | name  |   No  |  | |  Volume name.  |
 | options  |   No  |  | |  List with options to gather additional facts about Volume and related resources. Options allowed: `attachableVolumes`, `extraManagedVolumePaths`, and `snapshots`. For the option `snapshots`, you may provide a name.  |
-| params  |   |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: - `start`: The first item to return, using 0-based indexing. - `count`: The number of resources to return. - `filter`: A general filter/query string to narrow the list of items returned. - `sort`: The sort order of the returned data set.  |
+| params  |   No  |  | |  List of params to delimit, filter and sort the list of resources.  params allowed: `start`: The first item to return, using 0-based indexing. `count`: The number of resources to return. `filter`: A general filter/query string to narrow the list of items returned. `sort`: The sort order of the returned data set.  |
 
 
  
@@ -10239,8 +10013,6 @@ Retrieve facts about the OneView Volumes.
 - Check how to use environment variables for configuration at: https://github.com/HewlettPackard/oneview-ansible#environment-variables
 
 - Additional Playbooks for the HPE OneView Ansible modules can be found at: https://github.com/HewlettPackard/oneview-ansible/tree/master/examples
-
-- The OneView API version used will directly affect returned and expected fields in resources. Information on setting the desired API version and can be found at: https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version
 
 
 ---

--- a/test/oneview_module_loader.py
+++ b/test/oneview_module_loader.py
@@ -22,16 +22,16 @@ So, to avoid merging issues, and maintaining the tests code equal, we create a u
 configure the imports that change from one repository to another.
 """
 
-ONEVIEW_MODULE_UTILS_PATH = 'module_utils.oneview'
+ONEVIEW_MODULE_UTILS_PATH = 'ansible.module_utils.oneview'
 
-from module_utils.oneview import (HPOneViewException,
-                                  HPOneViewTaskError,
-                                  OneViewModuleBase,
-                                  SPKeys,
-                                  ServerProfileMerger,
-                                  ServerProfileReplaceNamesByUris,
-                                  ResourceComparator)
-from module_utils.icsp import ICspHelper
+from ansible.module_utils.oneview import (HPOneViewException,
+                                          HPOneViewTaskError,
+                                          OneViewModuleBase,
+                                          SPKeys,
+                                          ServerProfileMerger,
+                                          ServerProfileReplaceNamesByUris,
+                                          ResourceComparator)
+from ansible.module_utils.icsp import ICspHelper
 from image_streamer_artifact_bundle import ArtifactBundleModule
 from image_streamer_artifact_bundle_facts import ArtifactBundleFactsModule
 from image_streamer_build_plan import BuildPlanModule

--- a/test/oneview_module_loader.py
+++ b/test/oneview_module_loader.py
@@ -22,16 +22,22 @@ So, to avoid merging issues, and maintaining the tests code equal, we create a u
 configure the imports that change from one repository to another.
 """
 
-ONEVIEW_MODULE_UTILS_PATH = 'ansible.module_utils.oneview'
+import sys
+from module_utils import icsp, oneview
 
-from ansible.module_utils.oneview import (HPOneViewException,
-                                          HPOneViewTaskError,
-                                          OneViewModuleBase,
-                                          SPKeys,
-                                          ServerProfileMerger,
-                                          ServerProfileReplaceNamesByUris,
-                                          ResourceComparator)
-from ansible.module_utils.icsp import ICspHelper
+ONEVIEW_MODULE_UTILS_PATH = 'module_utils.oneview'
+
+sys.modules['ansible.module_utils.oneview'] = oneview
+sys.modules['ansible.module_utils.icsp'] = icsp
+
+from module_utils.oneview import (HPOneViewException,
+                                  HPOneViewTaskError,
+                                  OneViewModuleBase,
+                                  SPKeys,
+                                  ServerProfileMerger,
+                                  ServerProfileReplaceNamesByUris,
+                                  ResourceComparator)
+from module_utils.icsp import ICspHelper
 from image_streamer_artifact_bundle import ArtifactBundleModule
 from image_streamer_artifact_bundle_facts import ArtifactBundleFactsModule
 from image_streamer_build_plan import BuildPlanModule

--- a/test/test_hpe_icsp_os_deployment.py
+++ b/test/test_hpe_icsp_os_deployment.py
@@ -18,6 +18,7 @@
 
 import unittest
 import mock
+from oneview_module_loader import ICspHelper
 import hpe_icsp_os_deployment
 from copy import deepcopy
 

--- a/test/test_hpe_icsp_server.py
+++ b/test/test_hpe_icsp_server.py
@@ -21,6 +21,7 @@ import mock
 import yaml
 import json
 
+from oneview_module_loader import ICspHelper
 from hpe_icsp_server import (ICspServerModule,
                              main as hpe_icsp_server_main)
 

--- a/test/test_module_utils/test_icsp.py
+++ b/test/test_module_utils/test_icsp.py
@@ -18,7 +18,7 @@
 import unittest
 import mock
 
-from ansible.module_utils.icsp import ICspHelper
+from oneview_module_loader import ICspHelper
 
 DEFAULT_SERVER = {
     "name": "SP-01",

--- a/test/test_module_utils/test_icsp.py
+++ b/test/test_module_utils/test_icsp.py
@@ -18,7 +18,7 @@
 import unittest
 import mock
 
-from module_utils.icsp import ICspHelper
+from ansible.module_utils.icsp import ICspHelper
 
 DEFAULT_SERVER = {
     "name": "SP-01",

--- a/test/test_module_utils/test_oneview.py
+++ b/test/test_module_utils/test_oneview.py
@@ -19,16 +19,16 @@ import unittest
 import mock
 from copy import deepcopy
 
-from module_utils.oneview import (OneViewModuleBase,
-                                  ResourceComparator,
-                                  ResourceMerger,
-                                  OneViewClient,
-                                  HPOneViewException,
-                                  HPOneViewValueError,
-                                  ServerProfileReplaceNamesByUris,
-                                  SPKeys,
-                                  ServerProfileMerger,
-                                  HPOneViewResourceNotFound)
+from ansible.module_utils.oneview import (OneViewModuleBase,
+                                          ResourceComparator,
+                                          ResourceMerger,
+                                          OneViewClient,
+                                          HPOneViewException,
+                                          HPOneViewValueError,
+                                          ServerProfileReplaceNamesByUris,
+                                          SPKeys,
+                                          ServerProfileMerger,
+                                          HPOneViewResourceNotFound)
 
 MSG_GENERIC_ERROR = 'Generic error message'
 MSG_GENERIC = "Generic message"

--- a/test/test_oneview_firmware_driver.py
+++ b/test/test_oneview_firmware_driver.py
@@ -18,7 +18,7 @@
 
 import unittest
 from oneview_module_loader import FirmwareDriverModule
-from module_utils.oneview import (OneViewClient)
+from ansible.module_utils.oneview import OneViewClient
 from hpe_test_utils import OneViewBaseTestCase
 
 FIRMWARE_DRIVER_NAME = "Service Pack for ProLiant.iso"


### PR DESCRIPTION
### Description
This change allows users to specify the ansible_module_utils path to be used through the ENV variable `'ANSIBLE_MODULE_UTILS'` or by specifying the `'ansible_module_utils'` in the `ansible.cfg` file. 
It also removes the requirement for setting the `PYTHONPATH` env variable.

**This change breaks compatibility with previous versions** since having the `PYTHONPATH` variable setup now won't do anything, and the user will have to setup the `ANSIBLE_MODULE_UTILS` variable instead. 
This also helps reduce the differences in code between the ansible core repo and this repo.

### Issues Resolved
#273 & #297 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass. (`$ ./build.sh`).
- [X] New functionality has been documented in the README if applicable.

