### PR TITLE
Use pytest style to unit tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ setup () {
     export PYTHON_SDK=../python-hpOneView
   fi
 
-  export PYTHONPATH=$PYTHON_SDK:$ANSIBLE_LIBRARY:$PYTHONPATH
+  export PYTHONPATH="test:$PYTHON_SDK:$ANSIBLE_LIBRARY:$PYTHONPATH"
 }
 
 update_doc_fragments () {

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ setup () {
     export PYTHON_SDK=../python-hpOneView
   fi
 
-  export PYTHONPATH="test:$PYTHON_SDK:$ANSIBLE_LIBRARY:$PYTHONPATH"
+  export PYTHONPATH="$PYTHON_SDK:$ANSIBLE_LIBRARY:$PYTHONPATH"
 }
 
 update_doc_fragments () {

--- a/build.sh
+++ b/build.sh
@@ -128,14 +128,14 @@ if [ -z "$TRAVIS" ]; then
 #Coveralls runs only when Travis is running the build
 else
   echo -e "\n${COLOR_START}Running Coveralls${COLOR_END}"
-  coverage run --source=library/ -m unittest discover test/
+  coverage run --source=library/ -m pytest test/
   coveralls
   exit_code_coveralls=$?
 fi
 
 
 echo -e "\n${COLOR_START}Running tests${COLOR_END}"
-python -m unittest discover test/
+python -m pytest test/
 exit_code_tests=$?
 
 

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ setup () {
     export PYTHON_SDK=../python-hpOneView
   fi
 
-  export PYTHONPATH="$PYTHON_SDK:$ANSIBLE_LIBRARY:$PYTHONPATH"
+  export PYTHONPATH="test:$PYTHON_SDK:$ANSIBLE_LIBRARY:$PYTHONPATH"
 }
 
 update_doc_fragments () {

--- a/library/module_utils/oneview.py
+++ b/library/module_utils/oneview.py
@@ -337,7 +337,7 @@ class OneViewModuleBase(object):
         config=dict(type='path'),
         hostname=dict(type='str'),
         image_streamer_hostname=dict(type='str'),
-        password=dict(type='str'),
+        password=dict(type='str', no_log=True),
         username=dict(type='str')
     )
 

--- a/library/oneview_volume_facts.py
+++ b/library/oneview_volume_facts.py
@@ -135,12 +135,7 @@ from ansible.module_utils.oneview import OneViewModuleBase
 
 class VolumeFactsModule(OneViewModuleBase):
     def __init__(self):
-        argument_spec = dict(
-            name=dict(type='str'),
-            options=dict(type='list'),
-            params=dict(type='dict'),
-        )
-
+        argument_spec = dict(name=dict(type='str'), options=dict(type='list'), params=dict(type='dict'))
         super(VolumeFactsModule, self).__init__(additional_arg_spec=argument_spec)
         self.resource_client = self.oneview_client.volumes
 

--- a/library/oneview_volume_facts.py
+++ b/library/oneview_volume_facts.py
@@ -1,7 +1,20 @@
 #!/usr/bin/python
-
-# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# -*- coding: utf-8 -*-
+###
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],

--- a/library/oneview_volume_facts.py
+++ b/library/oneview_volume_facts.py
@@ -1,20 +1,7 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
-###
-# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-###
+
+# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],
@@ -26,7 +13,7 @@ module: oneview_volume_facts
 short_description: Retrieve facts about the OneView Volumes.
 description:
     - Retrieve facts about the Volumes from OneView.
-version_added: "2.3"
+version_added: "2.5"
 requirements:
     - "python >= 2.7.9"
     - "hpOneView >= 2.0.1"
@@ -39,8 +26,10 @@ options:
     options:
       description:
         - "List with options to gather additional facts about Volume and related resources.
-          Options allowed: C(attachableVolumes), C(extraManagedVolumePaths), and C(snapshots). For the option
-          C(snapshots), you may provide a name."
+          Options allowed:
+            - C(attachableVolumes)
+            - C(extraManagedVolumePaths)
+            - C(snapshots). For this option, you may provide a name."
       required: false
 extends_documentation_fragment:
     - oneview
@@ -50,29 +39,35 @@ extends_documentation_fragment:
 EXAMPLES = '''
 - name: Gather facts about all Volumes
   oneview_volume_facts:
-    config: "{{ config_path }}"
-
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
 - debug: var=storage_volumes
 
 - name: Gather paginated, filtered and sorted facts about Volumes
   oneview_volume_facts:
-    config: "{{ config }}"
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
     params:
       start: 0
       count: 2
       sort: 'name:descending'
       filter: "provisionType='Thin'"
-
 - debug: var=storage_volumes
 
 - name: "Gather facts about all Volumes, the attachable volumes managed by the appliance and the extra managed
          storage volume paths"
   oneview_volume_facts:
-    config: "{{ config_path }}"
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
     options:
         - attachableVolumes        # optional
         - extraManagedVolumePaths  # optional
-
 - debug: var=storage_volumes
 - debug: var=attachable_volumes
 - debug: var=extra_managed_volume_paths
@@ -80,23 +75,27 @@ EXAMPLES = '''
 
 - name: Gather facts about a Volume by name with a list of all snapshots taken
   oneview_volume_facts:
-    config: "{{ config }}"
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
     name: "{{ volume_name }}"
     options:
         - snapshots  # optional
-
 - debug: var=storage_volumes
 - debug: var=snapshots
 
 
 - name: "Gather facts about a Volume with one specific snapshot taken"
   oneview_volume_facts:
-    config: "{{ config }}"
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
     name: "{{ volume_name }}"
     options:
        - snapshots:  # optional
            name: "{{ snapshot_name }}"
-
 - debug: var=storage_volumes
 - debug: var=snapshots
 '''
@@ -124,9 +123,9 @@ from ansible.module_utils.oneview import OneViewModuleBase
 class VolumeFactsModule(OneViewModuleBase):
     def __init__(self):
         argument_spec = dict(
-            name=dict(required=False, type='str'),
-            options=dict(required=False, type='list'),
-            params=dict(required=False, type='dict'),
+            name=dict(type='str'),
+            options=dict(type='list'),
+            params=dict(type='dict'),
         )
 
         super(VolumeFactsModule, self).__init__(additional_arg_spec=argument_spec)
@@ -137,18 +136,18 @@ class VolumeFactsModule(OneViewModuleBase):
         networks = self.facts_params.pop('networks', None)
         if self.module.params.get('name'):
             ansible_facts['storage_volumes'] = self.resource_client.get_by('name', self.module.params['name'])
-            ansible_facts.update(self.__gather_facts_about_one_volume(ansible_facts['storage_volumes']))
+            ansible_facts.update(self._gather_facts_about_one_volume(ansible_facts['storage_volumes']))
         else:
             ansible_facts['storage_volumes'] = self.resource_client.get_all(**self.facts_params)
 
         if networks:
             self.facts_params['networks'] = networks
 
-        ansible_facts.update(self.__gather_facts_from_appliance())
+        ansible_facts.update(self._gather_facts_from_appliance())
 
         return dict(changed=False, ansible_facts=ansible_facts)
 
-    def __gather_facts_from_appliance(self):
+    def _gather_facts_from_appliance(self):
         facts = {}
 
         if self.options:
@@ -161,7 +160,7 @@ class VolumeFactsModule(OneViewModuleBase):
 
         return facts
 
-    def __gather_facts_about_one_volume(self, volumes):
+    def _gather_facts_about_one_volume(self, volumes):
         facts = {}
 
         if self.options.get('snapshots') and len(volumes) > 0:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,24 @@
+# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+
+from mock import Mock, patch
+from oneview_module_loader import ONEVIEW_MODULE_UTILS_PATH
+from hpOneView.oneview_client import OneViewClient
+
+
+@pytest.fixture
+def mock_ov_client():
+    patcher_json_file = patch.object(OneViewClient, 'from_json_file')
+    client = patcher_json_file.start()
+    return client.return_value
+
+
+@pytest.fixture
+def mock_ansible_module():
+    patcher_ansible = patch(ONEVIEW_MODULE_UTILS_PATH + '.AnsibleModule')
+    patcher_ansible = patcher_ansible.start()
+    ansible_module = Mock()
+    patcher_ansible.return_value = ansible_module
+    return ansible_module

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,18 @@
-# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+###
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 
 import pytest
 

--- a/test/hpe_test_utils.py
+++ b/test/hpe_test_utils.py
@@ -17,10 +17,87 @@
 ###
 
 import importlib
+import pytest
+import re
 import yaml
-from ansible.compat.tests import unittest, mock
+
+from ansible.compat.tests import mock
 from oneview_module_loader import ONEVIEW_MODULE_UTILS_PATH
 from hpOneView.oneview_client import OneViewClient
+
+
+class OneViewBaseTest(object):
+    @pytest.fixture(autouse=True)
+    def setUp(self, mock_ansible_module, mock_ov_client, request):
+        class_name = type(self).__name__
+        marker = request.node.get_marker('resource')
+        self.resource = getattr(mock_ov_client, "%s" % (marker.kwargs[class_name]))
+        self.mock_ov_client = mock_ov_client
+        self.mock_ansible_module = mock_ansible_module
+
+    @pytest.fixture
+    def testing_module(self):
+        resource_name = type(self).__name__.replace('Test', '')
+        resource_module_path_name = self.underscore(resource_name.replace('Module', ''))
+
+        testing_module = importlib.import_module('library.' + resource_module_path_name)
+        self.testing_class = getattr(testing_module, resource_name)
+        try:
+            # Load scenarios from module examples (Also checks if it is a valid yaml)
+            self.EXAMPLES = yaml.load(testing_module.EXAMPLES, yaml.SafeLoader)
+
+        except yaml.scanner.ScannerError:
+            message = "Something went wrong while parsing yaml from {}.EXAMPLES".format(self.testing_class.__module__)
+            raise Exception(message)
+        return testing_module
+
+    def underscore(self, word):
+        word = re.findall('[A-Z][^A-Z]*', word)
+        word = 'oneview_' + str.join('_', word).lower()
+        return word
+
+    def test_main_function_should_call_run_method(self, testing_module, mock_ansible_module):
+        mock_ansible_module.params = {'config': 'config.json'}
+
+        main_func = getattr(testing_module, 'main')
+
+        with mock.patch.object(self.testing_class, "run") as mock_run:
+            main_func()
+            mock_run.assert_called_once()
+
+
+class OneViewBaseFactsTest(OneViewBaseTest):
+    def test_should_get_all_using_filters(self, testing_module):
+        self.resource.get_all.return_value = []
+
+        params_get_all_with_filters = dict(
+            config='config.json',
+            name=None,
+            params={
+                'start': 1,
+                'count': 3,
+                'sort': 'name:descending',
+                'filter': 'purpose=General',
+                'query': 'imported eq true'
+            })
+        self.mock_ansible_module.params = params_get_all_with_filters
+
+        self.testing_class().run()
+
+        self.resource.get_all.assert_called_once_with(start=1, count=3, sort='name:descending', filter='purpose=General', query='imported eq true')
+
+    def test_should_get_all_without_params(self, testing_module):
+        self.resource.get_all.return_value = []
+
+        params_get_all_with_filters = dict(
+            config='config.json',
+            name=None
+        )
+        self.mock_ansible_module.params = params_get_all_with_filters
+
+        self.testing_class().run()
+
+        self.resource.get_all.assert_called_once_with()
 
 
 class OneViewBaseTestCase(object):
@@ -55,7 +132,7 @@ class OneViewBaseTestCase(object):
         self.mock_ansible_module = mock.Mock()
         mock_ansible_module.return_value = self.mock_ansible_module
 
-        self.__set_module_examples()
+        self._set_module_examples()
 
     def test_main_function_should_call_run_method(self):
         self.mock_ansible_module.params = {'config': 'config.json'}
@@ -66,7 +143,7 @@ class OneViewBaseTestCase(object):
             main_func()
             mock_run.assert_called_once_with()
 
-    def __set_module_examples(self):
+    def _set_module_examples(self):
         self.testing_module = importlib.import_module(self.testing_class.__module__)
 
         try:

--- a/test/hpe_test_utils.py
+++ b/test/hpe_test_utils.py
@@ -21,7 +21,7 @@ import pytest
 import re
 import yaml
 
-from ansible.compat.tests import mock
+from mock import mock
 from oneview_module_loader import ONEVIEW_MODULE_UTILS_PATH
 from hpOneView.oneview_client import OneViewClient
 

--- a/test/test_oneview.py
+++ b/test/test_oneview.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
-
 import logging
 import sys
 from module_utils import oneview
@@ -74,7 +73,7 @@ class OneViewModuleBaseSpec(unittest.TestCase):
                          'config': {'type': 'path'},
                          'hostname': {'type': 'str'},
                          'image_streamer_hostname': {'type': 'str'},
-                         'password': {'type': 'str'},
+                         'password': {'type': 'str', 'no_log': True},
                          'username': {'type': 'str'},
                          'validate_etag': {'type': 'bool', 'default': True}}
 

--- a/test/test_oneview_volume_facts.py
+++ b/test/test_oneview_volume_facts.py
@@ -1,5 +1,18 @@
-# Copyright: (c) 2016-2017 Hewlett Packard Enterprise Development LP
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+###
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
 
 import pytest
 

--- a/test/test_oneview_volume_facts.py
+++ b/test/test_oneview_volume_facts.py
@@ -1,26 +1,10 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
-###
-# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-###
+# Copyright: (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from ansible.compat.tests import unittest
+import pytest
+
 from oneview_module_loader import VolumeFactsModule
-from hpe_test_utils import FactsParamsTestCase
-
-ERROR_MSG = 'Fake message error'
+from hpe_test_utils import OneViewBaseFactsTest
 
 PARAMS_GET_ALL = dict(
     config='config.json',
@@ -56,13 +40,8 @@ PARAMS_GET_SNAPSHOT_BY_NAME = dict(
     options=[{"snapshots": {"name": 'snapshot_name'}}])
 
 
-class VolumeFactsSpec(unittest.TestCase,
-                      FactsParamsTestCase):
-    def setUp(self):
-        self.configure_mocks(self, VolumeFactsModule)
-        self.resource = self.mock_ov_client.volumes
-        FactsParamsTestCase.configure_client_mock(self, self.resource)
-
+@pytest.mark.resource(TestVolumeFactsModule='volumes')
+class TestVolumeFactsModule(OneViewBaseFactsTest):
     def test_should_get_all_volumes(self):
         self.resource.get_all.return_value = [{"name": "Test Volume"}]
         self.mock_ansible_module.params = PARAMS_GET_ALL
@@ -130,4 +109,4 @@ class VolumeFactsSpec(unittest.TestCase,
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main([__file__])

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,4 +2,5 @@ coverage
 coveralls
 flake8
 mock
+pytest
 six


### PR DESCRIPTION
### Description
Changes unit tests of VolumeFactsModule to use pytest style

All commits does:
- Changes default execution of tests on build.sh to pytest
- Adds base classes to be used by new tests using pytest style
- Adds support for Oneview VolumeFactsModule
  - Updates docs
  - Updates class style to use pytest

### Issues resolved
#307 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass. (`$ ./build.sh`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
