### PR TITLE
Add auth_login_domain parameter

### DIFF
--- a/library/module_utils/oneview.py
+++ b/library/module_utils/oneview.py
@@ -338,7 +338,8 @@ class OneViewModuleBase(object):
         hostname=dict(type='str'),
         image_streamer_hostname=dict(type='str'),
         password=dict(type='str', no_log=True),
-        username=dict(type='str')
+        username=dict(type='str'),
+        auth_login_domain=dict(type='str')
     )
 
     ONEVIEW_VALIDATE_ETAG_ARGS = dict(validate_etag=dict(type='bool', default=True))
@@ -390,7 +391,8 @@ class OneViewModuleBase(object):
     def _create_oneview_client(self):
         if self.module.params.get('hostname'):
             config = dict(ip=self.module.params['hostname'],
-                          credentials=dict(userName=self.module.params['username'], password=self.module.params['password']),
+                          credentials=dict(userName=self.module.params['username'], password=self.module.params['password'],
+                                           authLoginDomain=self.module.params.get('auth_login_domain', '')),
                           api_version=self.module.params['api_version'],
                           image_streamer_ip=self.module.params['image_streamer_hostname'])
             self.oneview_client = OneViewClient(config)

--- a/test/test_oneview.py
+++ b/test/test_oneview.py
@@ -78,6 +78,7 @@ class TestOneViewModuleBase():
                          'image_streamer_hostname': {'type': 'str'},
                          'password': {'type': 'str', 'no_log': True},
                          'username': {'type': 'str'},
+                         'auth_login_domain': {'type': 'str'},
                          'validate_etag': {'type': 'bool', 'default': True}}
 
     @pytest.fixture(autouse=True)
@@ -170,7 +171,22 @@ class TestOneViewModuleBase():
         params = {'hostname': '172.16.1.1', 'username': 'admin', 'password': 'mypass', 'api_version': 500,
                   'image_streamer_hostname': '172.16.1.2'}
         params_for_expect = {'image_streamer_ip': '172.16.1.2', 'api_version': 500, 'ip': '172.16.1.1',
-                             'credentials': {'userName': 'admin', 'password': 'mypass'}}
+                             'credentials': {'userName': 'admin', 'password': 'mypass', 'authLoginDomain': ''}}
+        self.mock_ansible_module.params = params
+
+        with mock.patch('module_utils.oneview.OneViewClient', first='one', second='two') as mock_ov_client_from_credentials:
+            OneViewModuleBase()
+
+        self.mock_ov_client_from_env_vars.not_been_called()
+        self.mock_ov_client_from_json_file.not_been_called()
+        mock_ov_client_from_credentials.assert_called_once_with(params_for_expect)
+
+    def test_should_load_config_from_parameters_with_domain(self):
+
+        params = {'hostname': '172.16.1.1', 'username': 'admin', 'password': 'mypass', 'api_version': 500,
+                  'image_streamer_hostname': '172.16.1.2', 'auth_login_domain': 'ADDomain'}
+        params_for_expect = {'image_streamer_ip': '172.16.1.2', 'api_version': 500, 'ip': '172.16.1.1',
+                             'credentials': {'userName': 'admin', 'password': 'mypass', 'authLoginDomain': 'ADDomain'}}
         self.mock_ansible_module.params = params
 
         with mock.patch('module_utils.oneview.OneViewClient', first='one', second='two') as mock_ov_client_from_credentials:


### PR DESCRIPTION
### Description
Presently, it is not possible to use Ansible parameters for authentication if you need to specify a login domain.

### Issues Resolved
Fixes #365 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass. (`$ ./build.sh`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
