### PR TITLE
Do name lookups for nativeNetworkUri in oneview_network_set

### DIFF
--- a/library/oneview_network_set.py
+++ b/library/oneview_network_set.py
@@ -165,6 +165,8 @@ class NetworkSetModule(OneViewModuleBase):
     def __replace_network_name_by_uri(self, data):
         if 'networkUris' in data:
             data['networkUris'] = [self.__get_network_uri(x) for x in data['networkUris']]
+        if 'nativeNetworkUri' in data:
+            data['nativeNetworkUri'] = self.__get_network_uri(data['nativeNetworkUri'])
 
 
 def main():

--- a/test/test_oneview_network_set.py
+++ b/test/test_oneview_network_set.py
@@ -119,6 +119,18 @@ class TestNetworkSetModule(OneViewBaseTest):
         self.mock_ansible_module.fail_json.assert_called_once_with(
             exception=mock.ANY, msg=NetworkSetModule.MSG_ETHERNET_NETWORK_NOT_FOUND + "Name of a Network")
 
+    def test_should_raise_exception_when_native_ethernet_network_not_found(self):
+        self.resource.get_by.side_effect = [NETWORK_SET], []
+        self.mock_ov_client.ethernet_networks.get_by.return_value = []
+
+        self.mock_ansible_module.params = PARAMS_WITH_CHANGES.copy()
+        self.mock_ansible_module.params['data']['nativeNetworkUri'] = ['Name of a Network']
+
+        NetworkSetModule().run()
+
+        self.mock_ansible_module.fail_json.assert_called_once_with(
+            exception=mock.ANY, msg=NetworkSetModule.MSG_ETHERNET_NETWORK_NOT_FOUND + "Name of a Network")
+
     def test_should_remove_network(self):
         self.resource.get_by.return_value = [NETWORK_SET]
 

--- a/test/test_oneview_network_set.py
+++ b/test/test_oneview_network_set.py
@@ -122,14 +122,14 @@ class TestNetworkSetModule(OneViewBaseTest):
     def test_should_raise_exception_when_native_ethernet_network_not_found(self):
         self.resource.get_by.side_effect = [NETWORK_SET], []
         self.mock_ov_client.ethernet_networks.get_by.return_value = []
-
         self.mock_ansible_module.params = PARAMS_WITH_CHANGES.copy()
-        self.mock_ansible_module.params['data']['nativeNetworkUri'] = ['Name of a Network']
+        self.mock_ansible_module.params['data']['networkUris'] = ['/rest/ethernet-networks/aaa-bbb-ccc']
+        self.mock_ansible_module.params['data']['nativeNetworkUri'] = 'Name of a Native Network'
 
         NetworkSetModule().run()
 
         self.mock_ansible_module.fail_json.assert_called_once_with(
-            exception=mock.ANY, msg=NetworkSetModule.MSG_ETHERNET_NETWORK_NOT_FOUND + "Name of a Network")
+            exception=mock.ANY, msg=NetworkSetModule.MSG_ETHERNET_NETWORK_NOT_FOUND + "Name of a Native Network")
 
     def test_should_remove_network(self):
         self.resource.get_by.return_value = [NETWORK_SET]


### PR DESCRIPTION
### Description
This small fixes makes it so a network name can be used instead of a uri for the nativeNetworkUri in the oneview_network_set module.

### Issues Resolved
Fixes #364 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass. (`$ ./build.sh`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
