### PR TITLE
Updated serverprofileReplaceName class to support networkname field for API600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 This release adds the [endpoints-support.md](endpoints-support.md) file.
 
+#### Big fixes
+- [#392](https://github.com/HewlettPackard/oneview-ansible/issues/392) Use networkName field for SP with API600
+
 ## v5.1.1
 
 This release extends the planned support for the OneView REST API v600

--- a/library/module_utils/oneview.py
+++ b/library/module_utils/oneview.py
@@ -790,11 +790,17 @@ class ServerProfileReplaceNamesByUris(object):
                                   self.oneview_client.enclosure_groups)
 
     def _replace_networks_name_by_uri(self, data):
-        if SPKeys.CONNECTIONS in data and data[SPKeys.CONNECTIONS]:
-            for connection in data[SPKeys.CONNECTIONS]:
-                if 'networkName' in connection:
-                    name = connection.pop('networkName', None)
-                    connection['networkUri'] = self._get_network_by_name(name)['uri']
+        if data.get("connections"):
+            connections = data["connections"]
+        elif data.get("connectionSettings") and data["connectionSettings"].get("connections"):
+            connections = data["connectionSettings"]["connections"]
+        else:
+            return
+
+        for connection in connections:
+            if 'networkName' in connection:
+                name = connection.pop('networkName', None)
+                connection['networkUri'] = self._get_network_by_name(name)['uri']
 
     def _replace_server_hardware_type_name_by_uri(self, data):
         self._replace_name_by_uri(data, 'serverHardwareTypeName', self.SERVER_HARDWARE_TYPE_NOT_FOUND,

--- a/library/module_utils/oneview.py
+++ b/library/module_utils/oneview.py
@@ -799,7 +799,7 @@ class ServerProfileReplaceNamesByUris(object):
 
         for connection in connections:
             if 'networkName' in connection:
-                name = connection.pop('networkName', None)
+                name = connection.pop('networkName')
                 connection['networkUri'] = self._get_network_by_name(name)['uri']
 
     def _replace_server_hardware_type_name_by_uri(self, data):


### PR DESCRIPTION
### Description
Updated serverProfileReplacename class to support API version 600.

### Issues Resolved
Fixes #392 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass. (`$ ./build.sh`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
