### PR TITLE
Updated server profile/template to accept name for network set

### DIFF
--- a/library/module_utils/oneview.py
+++ b/library/module_utils/oneview.py
@@ -1123,6 +1123,10 @@ class ServerProfileReplaceNamesByUris(object):
         if fcoe_networks:
             return fcoe_networks[0]
 
+        network_sets = self.oneview_client.network_sets.get_by('name', name)
+        if network_sets:
+            return network_sets[0]
+
         ethernet_networks = self.oneview_client.ethernet_networks.get_by('name', name)
         if not ethernet_networks:
             raise OneViewModuleResourceNotFound(self.SERVER_PROFILE_NETWORK_NOT_FOUND + name)

--- a/test/test_oneview.py
+++ b/test/test_oneview.py
@@ -1690,12 +1690,14 @@ class TestServerProfileReplaceNamesByUris():
     PROFILE_CONNECTIONS = [{"name": "connection-1", "networkUri": "/rest/fc-networks/98"},
                            {"name": "connection-2", "networkName": "FC Network"},
                            {"name": "connection-3", "networkName": "FCoE Network"},
-                           {"name": "connection-4", "networkName": 'Ethernet Network'}]
+                           {"name": "connection-4", "networkName": "Network Set"},
+                           {"name": "connection-5", "networkName": 'Ethernet Network'}]
 
     PROFILE_CONNECTIONS_WITH_NETWORK_URIS = [{"name": "connection-1", "networkUri": "/rest/fc-networks/98"},
                                              {"name": "connection-2", "networkUri": "/rest/fc-networks/14"},
                                              {"name": "connection-3", "networkUri": "/rest/fcoe-networks/16"},
-                                             {"name": "connection-4", "networkUri": "/rest/ethernet-networks/18"}]
+                                             {"name": "connection-4", "networkUri": "/rest/network-sets/20"},
+                                             {"name": "connection-5", "networkUri": "/rest/ethernet-networks/18"}]
 
     @pytest.fixture(autouse=True)
     def setUp(self):
@@ -1764,8 +1766,9 @@ class TestServerProfileReplaceNamesByUris():
         sp_data = deepcopy(self.BASIC_PROFILE)
         sp_data[SPKeys.CONNECTIONS] = self.PROFILE_CONNECTIONS
 
-        self.mock_ov_client.fc_networks.get_by.side_effect = [[dict(uri='/rest/fc-networks/14')], [], []]
-        self.mock_ov_client.fcoe_networks.get_by.side_effect = [[dict(uri='/rest/fcoe-networks/16')], []]
+        self.mock_ov_client.fc_networks.get_by.side_effect = [[dict(uri='/rest/fc-networks/14')], [], [], []]
+        self.mock_ov_client.fcoe_networks.get_by.side_effect = [[dict(uri='/rest/fcoe-networks/16')], [], []]
+        self.mock_ov_client.network_sets.get_by.side_effect = [[dict(uri='/rest/network-sets/20')], []]
         self.mock_ov_client.ethernet_networks.get_by.return_value = [dict(uri='/rest/ethernet-networks/18')]
 
         ServerProfileReplaceNamesByUris().replace(self.mock_ov_client, sp_data)
@@ -1777,8 +1780,9 @@ class TestServerProfileReplaceNamesByUris():
         sp_data = deepcopy(self.BASIC_PROFILE)
         sp_data["connectionSettings"] = {SPKeys.CONNECTIONS: self.PROFILE_CONNECTIONS}
 
-        self.mock_ov_client.fc_networks.get_by.side_effect = [[dict(uri='/rest/fc-networks/14')], [], []]
-        self.mock_ov_client.fcoe_networks.get_by.side_effect = [[dict(uri='/rest/fcoe-networks/16')], []]
+        self.mock_ov_client.fc_networks.get_by.side_effect = [[dict(uri='/rest/fc-networks/14')], [], [], []]
+        self.mock_ov_client.fcoe_networks.get_by.side_effect = [[dict(uri='/rest/fcoe-networks/16')], [], []]
+        self.mock_ov_client.network_sets.get_by.side_effect = [[dict(uri='/rest/network-sets/20')], []]
         self.mock_ov_client.ethernet_networks.get_by.return_value = [dict(uri='/rest/ethernet-networks/18')]
 
         ServerProfileReplaceNamesByUris().replace(self.mock_ov_client, sp_data)
@@ -1794,6 +1798,7 @@ class TestServerProfileReplaceNamesByUris():
 
         self.mock_ov_client.fc_networks.get_by.return_value = []
         self.mock_ov_client.fcoe_networks.get_by.return_value = []
+        self.mock_ov_client.network_sets.get_by.return_value = []
         self.mock_ov_client.ethernet_networks.get_by.return_value = []
 
         expected_error = ServerProfileReplaceNamesByUris.SERVER_PROFILE_NETWORK_NOT_FOUND + "FC Network"

--- a/test/test_oneview_server_profile.py
+++ b/test/test_oneview_server_profile.py
@@ -681,14 +681,16 @@ class TestServerProfileModule(OneViewBaseTest):
         conn_1 = dict(name="connection-1", networkUri='/rest/fc-networks/98')
         conn_2 = dict(name="connection-2", networkName='FC Network')
         conn_3 = dict(name="connection-3", networkName='FCoE Network')
-        conn_4 = dict(name="connection-4", networkName='Ethernet Network')
+        conn_4 = dict(name="connection-4", networkName='Network Set')
+        conn_5 = dict(name="connection-5", networkName='Ethernet Network')
 
         params = deepcopy(PARAMS_FOR_PRESENT)
-        params['data'][SPKeys.CONNECTIONS] = [conn_1, conn_2, conn_3, conn_4]
+        params['data'][SPKeys.CONNECTIONS] = [conn_1, conn_2, conn_3, conn_4, conn_5]
 
         self.resource.get_by_name.return_value = None
-        self.mock_ov_client.fc_networks.get_by.side_effect = [[dict(uri='/rest/fc-networks/14')], [], []]
-        self.mock_ov_client.fcoe_networks.get_by.side_effect = [[dict(uri='/rest/fcoe-networks/16')], []]
+        self.mock_ov_client.fc_networks.get_by.side_effect = [[dict(uri='/rest/fc-networks/14')], [], [], []]
+        self.mock_ov_client.fcoe_networks.get_by.side_effect = [[dict(uri='/rest/fcoe-networks/16')], [], []]
+        self.mock_ov_client.network_sets.get_by.side_effect = [[dict(uri='/rest/network-sets/15')], []]
         self.mock_ov_client.ethernet_networks.get_by.return_value = [dict(uri='/rest/ethernet-networks/18')]
         self.mock_ansible_module.params = deepcopy(params)
 
@@ -697,7 +699,8 @@ class TestServerProfileModule(OneViewBaseTest):
         expected_connections = [dict(name="connection-1", networkUri='/rest/fc-networks/98'),
                                 dict(name="connection-2", networkUri='/rest/fc-networks/14'),
                                 dict(name="connection-3", networkUri='/rest/fcoe-networks/16'),
-                                dict(name="connection-4", networkUri='/rest/ethernet-networks/18')]
+                                dict(name="connection-4", networkUri='/rest/network-sets/15'),
+                                dict(name="connection-5", networkUri='/rest/ethernet-networks/18')]
 
         args, _ = self.resource.create.call_args
         assert(args[0].get(SPKeys.CONNECTIONS) == expected_connections)
@@ -712,6 +715,7 @@ class TestServerProfileModule(OneViewBaseTest):
         self.mock_ov_client.fc_networks.get_by.return_value = []
         self.mock_ov_client.fcoe_networks.get_by.return_value = []
         self.mock_ov_client.ethernet_networks.get_by.return_value = []
+        self.mock_ov_client.network_sets.get_by.return_value = []
         self.mock_ansible_module.params = deepcopy(params)
 
         ServerProfileModule().run()
@@ -1616,14 +1620,16 @@ class TestServerProfileModule(OneViewBaseTest):
         conn_1 = dict(name="connection-1", networkUri='/rest/fc-networks/98')
         conn_2 = dict(name="connection-2", networkName='FC Network')
         conn_3 = dict(name="connection-3", networkName='FCoE Network')
-        conn_4 = dict(name="connection-4", networkName='Ethernet Network')
+        conn_4 = dict(name="connection-4", networkName='Network set')
+        conn_5 = dict(name="connection-5", networkName='Ethernet Network')
 
         params = deepcopy(PARAMS_FOR_PRESENT)
-        params['data'][SPKeys.CONNECTIONS] = [conn_1, conn_2, conn_3, conn_4]
+        params['data'][SPKeys.CONNECTIONS] = [conn_1, conn_2, conn_3, conn_4, conn_5]
 
         self.resource.data = deepcopy(BASIC_PROFILE)
-        self.mock_ov_client.fc_networks.get_by.side_effect = [[dict(uri='/rest/fc-networks/14')], [], []]
-        self.mock_ov_client.fcoe_networks.get_by.side_effect = [[dict(uri='/rest/fcoe-networks/16')], []]
+        self.mock_ov_client.fc_networks.get_by.side_effect = [[dict(uri='/rest/fc-networks/14')], [], [], []]
+        self.mock_ov_client.fcoe_networks.get_by.side_effect = [[dict(uri='/rest/fcoe-networks/16')], [], []]
+        self.mock_ov_client.network_sets.get_by.side_effect = [[dict(uri='/rest/network-sets/20')], []]
         self.mock_ov_client.ethernet_networks.get_by.return_value = [dict(uri='/rest/ethernet-networks/18')]
         self.mock_ansible_module.params = deepcopy(params)
 
@@ -1632,7 +1638,8 @@ class TestServerProfileModule(OneViewBaseTest):
         expected_connections = [dict(name="connection-1", networkUri='/rest/fc-networks/98'),
                                 dict(name="connection-2", networkUri='/rest/fc-networks/14'),
                                 dict(name="connection-3", networkUri='/rest/fcoe-networks/16'),
-                                dict(name="connection-4", networkUri='/rest/ethernet-networks/18')]
+                                dict(name="connection-4", networkUri='/rest/network-sets/20'),
+                                dict(name="connection-5", networkUri='/rest/ethernet-networks/18')]
 
         args, _ = self.resource.update.call_args
         assert(args[0].get(SPKeys.CONNECTIONS) == expected_connections)
@@ -1647,6 +1654,7 @@ class TestServerProfileModule(OneViewBaseTest):
         self.mock_ov_client.fc_networks.get_by.return_value = []
         self.mock_ov_client.fcoe_networks.get_by.return_value = []
         self.mock_ov_client.ethernet_networks.get_by.return_value = []
+        self.mock_ov_client.network_sets.get_by.return_value = []
         self.mock_ansible_module.params = deepcopy(params)
 
         ServerProfileModule().run()


### PR DESCRIPTION
### Description
Updated Server profile and template to accept both name and URI of networkset.

### Issues Resolved
Fixes #438 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass. (`$ ./build.sh`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
