### PR TITLE
fixed issue 489 - SP creation fails when enclosure uri is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Ansible Modules for HPE OneView Change Log
+## v5.6.0 (Unreleased)
+
+#### Bug fixes & Enhancements
+- [#489](https://github.com/HewlettPackard/oneview-ansible/issues/489) Server Profile - create operation fails with an error -Value specified for enclosure is not valid or not supported
 
 ## v5.5.0
 This release extends the planned support of the modules to OneView REST API version 800 (OneView v4.1), 1000 (OneView v4.2) and 1200 (OneView v5.0).

--- a/library/oneview_server_profile.py
+++ b/library/oneview_server_profile.py
@@ -257,7 +257,7 @@ class ServerProfileModule(OneViewModule):
         state=dict(choices=['present', 'absent', 'compliant'], default='present'),
         data=dict(type='dict', required=True),
         params=dict(type='dict', required=False),
-        auto_assign_server_hardware=dict(type='bool', default=False)
+        auto_assign_server_hardware=dict(type='bool', default=True)
     )
 
     def __init__(self):

--- a/library/oneview_server_profile.py
+++ b/library/oneview_server_profile.py
@@ -257,7 +257,7 @@ class ServerProfileModule(OneViewModule):
         state=dict(choices=['present', 'absent', 'compliant'], default='present'),
         data=dict(type='dict', required=True),
         params=dict(type='dict', required=False),
-        auto_assign_server_hardware=dict(type='bool', default=True)
+        auto_assign_server_hardware=dict(type='bool', default=False)
     )
 
     def __init__(self):
@@ -330,8 +330,10 @@ class ServerProfileModule(OneViewModule):
                 if self.data.get('serverHardwareUri') is None and server_hardware_uri_exists:
                     self.data['serverHardwareUri'] = None
 
-            # Auto assigns a Server Hardware to Server Profile if auto_assign_server_hardware is True and no SH uris exist
-            if not self.current_resource.data.get('serverHardwareUri') and not self.data.get('serverHardwareUri') and self.auto_assign_server_hardware:
+            # Auto assigns a Server Hardware to Server Profile if auto_assign_server_hardware is True and no SH uris/enclosure uri and bay exist
+            if not self.current_resource.data.get('serverHardwareUri') and not self.data.get('serverHardwareUri') and self.auto_assign_server_hardware \
+                and not self.current_resource.data.get('enclosureUri') and not self.current_resource.data.get('enclosureBay') \
+                    and not self.data.get('enclosureUri') and not self.data.get('enclosureBay'):
                 self.data['serverHardwareUri'] = self._auto_assign_server_profile()
 
             merged_data = ServerProfileMerger().merge_data(self.current_resource.data, self.data)
@@ -522,9 +524,14 @@ class ServerProfileModule(OneViewModule):
             return
 
         self.module.log(msg="Finding an available server hardware")
-        available_server_hardware = self.resource_client.get_available_servers(
-            enclosureGroupUri=enclosure_group,
-            serverHardwareTypeUri=server_hardware_type)
+        if self.oneview_client.api_version >= 1600:
+            available_server_hardware = self.resource_client.get_available_targets(
+                enclosureGroupUri=enclosure_group,
+                serverHardwareTypeUri=server_hardware_type)['targets']
+        else:
+            available_server_hardware = self.resource_client.get_available_servers(
+                enclosureGroupUri=enclosure_group,
+                serverHardwareTypeUri=server_hardware_type)
 
         # targets will list empty bays. We need to pick one that has a server
         index = 0
@@ -625,8 +632,9 @@ class ServerProfileModule(OneViewModule):
 
     def _auto_assign_server_profile(self):
         server_hardware_uri = self.data.get('serverHardwareUri')
-
-        if not server_hardware_uri and self.auto_assign_server_hardware:
+        enclosure_uri = self.data.get('enclosureUri')
+        enclosure_bay = self.data.get('enclosureBay')
+        if not server_hardware_uri and self.auto_assign_server_hardware and not enclosure_uri and not enclosure_bay:
             # find servers that have no profile, matching Server hardware type and enclosure group
             self.module.log(msg="Get an available Server Hardware for the Profile")
             server_hardware_uri = self.__get_available_server_hardware_uri()

--- a/test/test_oneview_server_profile.py
+++ b/test/test_oneview_server_profile.py
@@ -201,6 +201,7 @@ class TestServerProfileModule(OneViewBaseTest):
 
     @pytest.fixture(autouse=True)
     def specific_set_up(self):
+        self.mock_ov_client.api_version = 1000
         self.sleep_patch = mock.patch('time.sleep')
         self.sleep_patch.start()
         self.sleep_patch.return_value = None
@@ -283,8 +284,7 @@ class TestServerProfileModule(OneViewBaseTest):
         self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=True, msg=ServerProfileModule.MSG_REMEDIATED_COMPLIANCE, ansible_facts=mock_facts)
 
-    def test_should_create_with_automatically_selected_hardware_when_not_exists_api1000(self):
-        self.mock_ov_client.api_version = 1000
+    def test_should_create_with_automatically_selected_hardware_when_not_exists(self):
         profile_data = deepcopy(BASIC_PROFILE)
         profile_data['serverHardwareUri'] = '/rest/server-hardware/31393736-3831-4753-567h-30335837524E'
 

--- a/test/test_oneview_server_profile.py
+++ b/test/test_oneview_server_profile.py
@@ -115,7 +115,7 @@ AVAILABLE_SERVERS = [
     dict(enclosureBay=4, serverHardwareUri='/rest/server-hardware/37333036-3831-6776-gdfd-3037583rewr0'),
     dict(enclosureBay=8, serverHardwareUri='/rest/server-hardware/37333036-3831-4753-4831-303158sdf458')]
 
-AVAILABLE_TARGETS = dict(targets = [
+AVAILABLE_TARGETS = dict(targets=[
     dict(enclosureBay=2, serverHardwareUri=''),
     dict(enclosureBay=3, serverHardwareUri='/rest/server-hardware/31393736-3831-4753-567h-30335837524E'),
     dict(enclosureBay=4, serverHardwareUri='/rest/server-hardware/37333036-3831-6776-gdfd-3037583rewr0'),

--- a/test/test_oneview_server_profile.py
+++ b/test/test_oneview_server_profile.py
@@ -1,5 +1,5 @@
 ###
-# Copyright (2016-2019) Hewlett Packard Enterprise Development LP
+# Copyright (2016-2020) Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # You may not use this file except in compliance with the License.
@@ -114,6 +114,12 @@ AVAILABLE_SERVERS = [
     dict(enclosureBay=3, serverHardwareUri='/rest/server-hardware/31393736-3831-4753-567h-30335837524E'),
     dict(enclosureBay=4, serverHardwareUri='/rest/server-hardware/37333036-3831-6776-gdfd-3037583rewr0'),
     dict(enclosureBay=8, serverHardwareUri='/rest/server-hardware/37333036-3831-4753-4831-303158sdf458')]
+
+AVAILABLE_TARGETS = dict(targets = [
+    dict(enclosureBay=2, serverHardwareUri=''),
+    dict(enclosureBay=3, serverHardwareUri='/rest/server-hardware/31393736-3831-4753-567h-30335837524E'),
+    dict(enclosureBay=4, serverHardwareUri='/rest/server-hardware/37333036-3831-6776-gdfd-3037583rewr0'),
+    dict(enclosureBay=8, serverHardwareUri='/rest/server-hardware/37333036-3831-4753-4831-303158sdf458')])
 
 BOOT_CONN = dict(priority="NotBootable", chapLevel="none")
 
@@ -277,7 +283,8 @@ class TestServerProfileModule(OneViewBaseTest):
         self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=True, msg=ServerProfileModule.MSG_REMEDIATED_COMPLIANCE, ansible_facts=mock_facts)
 
-    def test_should_create_with_automatically_selected_hardware_when_not_exists(self):
+    def test_should_create_with_automatically_selected_hardware_when_not_exists_api1000(self):
+        self.mock_ov_client.api_version = 1000
         profile_data = deepcopy(BASIC_PROFILE)
         profile_data['serverHardwareUri'] = '/rest/server-hardware/31393736-3831-4753-567h-30335837524E'
 
@@ -285,6 +292,31 @@ class TestServerProfileModule(OneViewBaseTest):
         self.resource.data = CREATED_BASIC_PROFILE
         self.resource.create.return_value = self.resource
         self.resource.get_available_servers.return_value = AVAILABLE_SERVERS
+        self.mock_ov_client.server_hardware.data = {}
+        self.mock_ov_client.server_hardware.get_by_uri.return_value = self.mock_ov_client.server_hardware
+        self.mock_ansible_module.params = deepcopy(PARAMS_FOR_PRESENT)
+
+        mock_facts = gather_facts(self.mock_ov_client, created=True)
+
+        ServerProfileModule().run()
+
+        self.resource.create.assert_called_once_with(profile_data)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=ServerProfileModule.MSG_CREATED,
+            ansible_facts=mock_facts
+        )
+
+    def test_should_create_with_automatically_selected_hardware_when_not_exists_api1600(self):
+        self.mock_ov_client.api_version = 1600
+        profile_data = deepcopy(BASIC_PROFILE)
+        profile_data['serverHardwareUri'] = '/rest/server-hardware/31393736-3831-4753-567h-30335837524E'
+
+        self.resource.get_by_name.return_value = None
+        self.resource.data = CREATED_BASIC_PROFILE
+        self.resource.create.return_value = self.resource
+        self.resource.get_available_targets.return_value = AVAILABLE_TARGETS
         self.mock_ov_client.server_hardware.data = {}
         self.mock_ov_client.server_hardware.get_by_uri.return_value = self.mock_ov_client.server_hardware
         self.mock_ansible_module.params = deepcopy(PARAMS_FOR_PRESENT)


### PR DESCRIPTION
### Description
SP creation fails when enclosure uri is passed

### Issues Resolved
#489 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass. (`$ ./build.sh`).
- [x] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
