### PR TITLE
Added support for setting one-time boot option in server hardware

### DIFF
--- a/examples/oneview_server_hardware.yml
+++ b/examples/oneview_server_hardware.yml
@@ -128,6 +128,22 @@
             name: '{{ server_hardware_hostname }}'
       delegate_to: localhost
 
+    - name: Set the server one-time boot device to Network
+      oneview_server_hardware:
+        config: "{{ config }}"
+        state: one_time_boot_network
+        data:
+          name: '{{ server_hardware_hostname }}'
+      delegate_to: localhost
+
+    - name: Set the server one-time boot device to No one-time boot
+      oneview_server_hardware:
+        config: "{{ config }}"
+        state: one_time_boot_normal
+        data:
+          name: '{{ server_hardware_hostname }}'
+      delegate_to: localhost
+
     - name: Remove the server hardware by its IP
       oneview_server_hardware:
         config: "{{ config }}"

--- a/library/oneview_server_hardware.py
+++ b/library/oneview_server_hardware.py
@@ -45,9 +45,15 @@ options:
               C(uid_state_off) will set off the UID state, if necessary.
               C(environmental_configuration_set) will set the environmental configuration of the Server Hardware.
               C(multiple_servers_added) will add multiple rack-mount servers.
+              C(one_time_boot_normal) will set the server one-time boot device to No one-time boot.
+              C(one_time_boot_cdrom) will set the server one-time boot device to CD/DVD Drive.
+              C(one_time_boot_usb) will set the server one-time boot device to USB Storage Device.
+              C(one_time_boot_hdd) will set the server one-time boot device to Hard Disk Drive.
+              C(one_time_boot_network) will Set the server one-time boot device to Network.
         choices: ['present', 'absent', 'power_state_set', 'refresh_state_set', 'ilo_firmware_version_updated',
                   'ilo_state_reset','uid_state_on', 'uid_state_off', 'environmental_configuration_set',
-                  'multiple_servers_added']
+                  'multiple_servers_added', 'one_time_boot_normal', 'one_time_boot_cdrom', 'one_time_boot_usb',
+                  'one_time_boot_hdd', 'one_time_boot_network']
         required: true
     data:
         description:
@@ -180,6 +186,28 @@ EXAMPLES = '''
     data:
         name : '0000A66102, bay 12'
   delegate_to: localhost
+  
+- name: Set the server one-time boot device to Network
+  oneview_server_hardware:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 1200
+    state: one_time_boot_network
+    data:
+        name : '0000A66102, bay 12'
+  delegate_to: localhost
+  
+- name: Set the server one-time boot device to No one-time boot
+  oneview_server_hardware:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 1200
+    state: one_time_boot_normal
+    data:
+        name : '0000A66102, bay 12'
+  delegate_to: localhost
 '''
 
 RETURN = '''
@@ -208,17 +236,28 @@ class ServerHardwareModule(OneViewModule):
     MSG_ALREADY_ABSENT = 'Server Hardware is already absent.'
     MSG_MANDATORY_FIELD_MISSING = "Mandatory field was not informed: {0}"
     MSG_MULTIPLE_RACK_MOUNT_SERVERS_ADDED = "Servers added successfully."
+    MSG_ONE_TIME_BOOT_CHANGED = 'Server Hardware one-time boot state changed successfully.'
 
     patch_success_message = dict(
         ilo_state_reset=MSG_ILO_STATE_RESET,
         uid_state_on=MSG_UID_STATE_CHANGED,
-        uid_state_off=MSG_UID_STATE_CHANGED
+        uid_state_off=MSG_UID_STATE_CHANGED,
+        one_time_boot_normal=MSG_ONE_TIME_BOOT_CHANGED,
+        one_time_boot_cdrom=MSG_ONE_TIME_BOOT_CHANGED,
+        one_time_boot_usb=MSG_ONE_TIME_BOOT_CHANGED,
+        one_time_boot_hdd=MSG_ONE_TIME_BOOT_CHANGED,
+        one_time_boot_network=MSG_ONE_TIME_BOOT_CHANGED,
     )
 
     patch_params = dict(
         ilo_state_reset=dict(operation='replace', path='/mpState', value='Reset'),
         uid_state_on=dict(operation='replace', path='/uidState', value='On'),
-        uid_state_off=dict(operation='replace', path='/uidState', value='Off')
+        uid_state_off=dict(operation='replace', path='/uidState', value='Off'),
+        one_time_boot_normal=dict(operation='replace', path='/oneTimeBoot', value='NORMAL'),
+        one_time_boot_cdrom=dict(operation='replace', path='/oneTimeBoot', value='CDROM'),
+        one_time_boot_usb=dict(operation='replace', path='/oneTimeBoot', value='USB'),
+        one_time_boot_hdd=dict(operation='replace', path='/oneTimeBoot', value='HDD'),
+        one_time_boot_network=dict(operation='replace', path='/oneTimeBoot', value='NETWORK')
     )
 
     argument_spec = dict(
@@ -234,7 +273,12 @@ class ServerHardwareModule(OneViewModule):
                 'uid_state_on',
                 'uid_state_off',
                 'environmental_configuration_set',
-                'multiple_servers_added'
+                'multiple_servers_added',
+                'one_time_boot_normal',
+                'one_time_boot_cdrom',
+                'one_time_boot_usb',
+                'one_time_boot_hdd',
+                'one_time_boot_network'
             ]
         ),
         data=dict(required=True, type='dict')

--- a/library/oneview_server_hardware.py
+++ b/library/oneview_server_hardware.py
@@ -186,7 +186,7 @@ EXAMPLES = '''
     data:
         name : '0000A66102, bay 12'
   delegate_to: localhost
-  
+
 - name: Set the server one-time boot device to Network
   oneview_server_hardware:
     hostname: 172.16.101.48
@@ -197,7 +197,7 @@ EXAMPLES = '''
     data:
         name : '0000A66102, bay 12'
   delegate_to: localhost
-  
+
 - name: Set the server one-time boot device to No one-time boot
   oneview_server_hardware:
     hostname: 172.16.101.48

--- a/test/test_oneview_server_hardware.py
+++ b/test/test_oneview_server_hardware.py
@@ -646,6 +646,5 @@ class TestServerHardwareModule(OneViewBaseTest):
         )
 
 
-
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/test/test_oneview_server_hardware.py
+++ b/test/test_oneview_server_hardware.py
@@ -114,6 +114,40 @@ YAML_SERVER_HARDWARE_UID_STATE_OFF = """
             name : "172.18.6.15"
 """
 
+YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_NORMAL = """
+        config: config
+        state: one_time_boot_normal
+        data:
+            name : "172.18.6.15"
+"""
+
+YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_CDROM = """
+        config: config
+        state: one_time_boot_cdrom
+        data:
+            name : "172.18.6.15"
+"""
+YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_USB = """
+        config: config
+        state: one_time_boot_usb
+        data:
+            name : "172.18.6.15"
+"""
+
+YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_HDD = """
+        config: config
+        state: one_time_boot_hdd
+        data:
+            name : "172.18.6.15"
+"""
+
+YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_NETWORK = """
+        config: config
+        state: one_time_boot_network
+        data:
+            name : "172.18.6.15"
+"""
+
 SERVER_HARDWARE_HOSTNAME = "172.18.6.15"
 
 DICT_DEFAULT_SERVER_HARDWARE = yaml.load(YAML_SERVER_HARDWARE_PRESENT)["data"]
@@ -203,7 +237,9 @@ class TestServerHardwareModule(OneViewBaseTest):
 
         ServerHardwareModule().run()
 
-        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=ServerHardwareModule.MSG_MANDATORY_FIELD_MISSING.format('data.name'))
+        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY,
+                                                                   msg=ServerHardwareModule.MSG_MANDATORY_FIELD_MISSING.format(
+                                                                       'data.name'))
 
     def test_should_remove_server_hardware(self):
         self.resource.data = {'name': 'name'}
@@ -250,7 +286,8 @@ class TestServerHardwareModule(OneViewBaseTest):
 
         ServerHardwareModule().run()
 
-        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=ServerHardwareModule.MSG_SERVER_HARDWARE_NOT_FOUND)
+        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY,
+                                                                   msg=ServerHardwareModule.MSG_SERVER_HARDWARE_NOT_FOUND)
 
     def test_should_set_refresh_state(self):
         self.resource.data = {"uri": "resourceuri"}
@@ -273,7 +310,8 @@ class TestServerHardwareModule(OneViewBaseTest):
 
         ServerHardwareModule().run()
 
-        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=ServerHardwareModule.MSG_SERVER_HARDWARE_NOT_FOUND)
+        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY,
+                                                                   msg=ServerHardwareModule.MSG_SERVER_HARDWARE_NOT_FOUND)
 
     def test_should_set_ilo_firmware(self):
         self.resource.data = {"uri": "resourceuri"}
@@ -296,7 +334,8 @@ class TestServerHardwareModule(OneViewBaseTest):
 
         ServerHardwareModule().run()
 
-        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=ServerHardwareModule.MSG_SERVER_HARDWARE_NOT_FOUND)
+        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY,
+                                                                   msg=ServerHardwareModule.MSG_SERVER_HARDWARE_NOT_FOUND)
 
     def test_should_reset_ilo_state(self):
         server_hardware_uri = "resourceuri"
@@ -430,6 +469,182 @@ class TestServerHardwareModule(OneViewBaseTest):
             ansible_facts=dict(server_hardware=get_results),
             msg=ServerHardwareModule.MSG_ALREADY_PRESENT
         )
+
+    def test_should_set_one_time_boot_to_normal(self):
+        server_hardware_uri = "resourceuri"
+
+        self.resource.data = {"uri": server_hardware_uri, "oneTimeBoot": "NETWORK"}
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_NORMAL)
+
+        ServerHardwareModule().run()
+
+        patch_params = ServerHardwareModule.patch_params['one_time_boot_normal']
+        self.resource.patch.assert_called_once_with(**patch_params)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=ServerHardwareModule.MSG_ONE_TIME_BOOT_CHANGED,
+            ansible_facts=dict(server_hardware=self.resource.data)
+        )
+
+    def test_should_not_set_when_one_time_boot_is_already_normal(self):
+        server_hardware_uri = "resourceuri"
+        server_hardware = {"uri": server_hardware_uri, "oneTimeBoot": "NORMAL"}
+
+        self.resource.data = server_hardware
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_NORMAL)
+
+        ServerHardwareModule().run()
+
+        self.resource.patch.assert_not_called()
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=ServerHardwareModule.MSG_NOTHING_TO_DO,
+            ansible_facts=dict(server_hardware=server_hardware)
+        )
+
+    def test_should_set_one_time_boot_to_cdrom(self):
+        server_hardware_uri = "resourceuri"
+
+        self.resource.data = {"uri": server_hardware_uri, "oneTimeBoot": "NORMAL"}
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_CDROM)
+
+        ServerHardwareModule().run()
+
+        patch_params = ServerHardwareModule.patch_params['one_time_boot_cdrom']
+        self.resource.patch.assert_called_once_with(**patch_params)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=ServerHardwareModule.MSG_ONE_TIME_BOOT_CHANGED,
+            ansible_facts=dict(server_hardware=self.resource.data)
+        )
+
+    def test_should_not_set_when_one_time_boot_is_already_cdrom(self):
+        server_hardware_uri = "resourceuri"
+        server_hardware = {"uri": server_hardware_uri, "oneTimeBoot": "CDROM"}
+
+        self.resource.data = server_hardware
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_CDROM)
+
+        ServerHardwareModule().run()
+
+        self.resource.patch.assert_not_called()
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=ServerHardwareModule.MSG_NOTHING_TO_DO,
+            ansible_facts=dict(server_hardware=server_hardware)
+        )
+
+    def test_should_set_one_time_boot_to_usb(self):
+        server_hardware_uri = "resourceuri"
+
+        self.resource.data = {"uri": server_hardware_uri, "oneTimeBoot": "NORMAL"}
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_USB)
+
+        ServerHardwareModule().run()
+
+        patch_params = ServerHardwareModule.patch_params['one_time_boot_usb']
+        self.resource.patch.assert_called_once_with(**patch_params)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=ServerHardwareModule.MSG_ONE_TIME_BOOT_CHANGED,
+            ansible_facts=dict(server_hardware=self.resource.data)
+        )
+
+    def test_should_not_set_when_one_time_boot_is_already_usb(self):
+        server_hardware_uri = "resourceuri"
+        server_hardware = {"uri": server_hardware_uri, "oneTimeBoot": "USB"}
+
+        self.resource.data = server_hardware
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_USB)
+
+        ServerHardwareModule().run()
+
+        self.resource.patch.assert_not_called()
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=ServerHardwareModule.MSG_NOTHING_TO_DO,
+            ansible_facts=dict(server_hardware=server_hardware)
+        )
+
+    def test_should_set_one_time_boot_to_hdd(self):
+        server_hardware_uri = "resourceuri"
+
+        self.resource.data = {"uri": server_hardware_uri, "oneTimeBoot": "NORMAL"}
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_HDD)
+
+        ServerHardwareModule().run()
+
+        patch_params = ServerHardwareModule.patch_params['one_time_boot_hdd']
+        self.resource.patch.assert_called_once_with(**patch_params)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=ServerHardwareModule.MSG_ONE_TIME_BOOT_CHANGED,
+            ansible_facts=dict(server_hardware=self.resource.data)
+        )
+
+    def test_should_not_set_when_one_time_boot_is_already_hdd(self):
+        server_hardware_uri = "resourceuri"
+        server_hardware = {"uri": server_hardware_uri, "oneTimeBoot": "HDD"}
+
+        self.resource.data = server_hardware
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_HDD)
+
+        ServerHardwareModule().run()
+
+        self.resource.patch.assert_not_called()
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=ServerHardwareModule.MSG_NOTHING_TO_DO,
+            ansible_facts=dict(server_hardware=server_hardware)
+        )
+
+    def test_should_set_one_time_boot_to_network(self):
+        server_hardware_uri = "resourceuri"
+
+        self.resource.data = {"uri": server_hardware_uri, "oneTimeBoot": "NORMAL"}
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_NETWORK)
+
+        ServerHardwareModule().run()
+
+        patch_params = ServerHardwareModule.patch_params['one_time_boot_network']
+        self.resource.patch.assert_called_once_with(**patch_params)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=ServerHardwareModule.MSG_ONE_TIME_BOOT_CHANGED,
+            ansible_facts=dict(server_hardware=self.resource.data)
+        )
+
+    def test_should_not_set_when_one_time_boot_is_already_network(self):
+        server_hardware_uri = "resourceuri"
+        server_hardware = {"uri": server_hardware_uri, "oneTimeBoot": "NETWORK"}
+
+        self.resource.data = server_hardware
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ONE_TIME_BOOT_AS_NETWORK)
+
+        ServerHardwareModule().run()
+
+        self.resource.patch.assert_not_called()
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=ServerHardwareModule.MSG_NOTHING_TO_DO,
+            ansible_facts=dict(server_hardware=server_hardware)
+        )
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description
Added support for setting one-time boot option in server hardware. one-time boot option can be set to specified values as in Oneview API.

### Check List
- [yes ] New functionality includes testing.
- [ yes] All tests pass. (`$ ./build.sh`).
- [No ] New functionality has been documented in the README if applicable.
- [Yes ] New functionality has been thoroughly documented in the examples.
