### PR TITLE
Fix #597 - Rename of rack

### DIFF
--- a/library/module_utils/oneview.py
+++ b/library/module_utils/oneview.py
@@ -94,7 +94,8 @@ def transform_list_to_dict(list_):
 
 
 # Makes a deep merge of 2 dictionaries and returns the merged dictionary
-def dict_merge(resource_dict, data_dict):
+def dict_merge(original_resource_dict, data_dict):
+    resource_dict = deepcopy(original_resource_dict)
     for key, val in data_dict.items():
         if not resource_dict.get(key):
             resource_dict[key] = val

--- a/library/oneview_rack.py
+++ b/library/oneview_rack.py
@@ -128,6 +128,11 @@ class RackModule(OneViewModuleBase):
             return self.__absent()
 
     def __present(self):
+        # for idempotence, if current doesn't exist, replace with newName one
+        if not self.current_resource:
+            if "newName" in self.data:
+                self.current_resource = self.resource_client.get_by('name', self.data['newName'])
+                self.data["name"] = self.data.pop("newName")
         if not self.current_resource:
             self.current_resource = self.resource_client.add(self.data)
             changed = True
@@ -158,7 +163,7 @@ class RackModule(OneViewModuleBase):
 
         self.current_resource = self.current_resource[0]
         merged_rack_mounts = self.__mergeRackMounts()
-        merged_data = dict_merge(self.data, self.current_resource)
+        merged_data = dict_merge(self.current_resource, self.data)
         if "rackMounts" in merged_rack_mounts:
             merged_data['rackMounts'] = merged_rack_mounts['rackMounts']
         if not compare(self.current_resource, merged_data):


### PR DESCRIPTION

### Description
  fix rename of rack not functional neither idempotent
  fix dict_merge to not change content of first argument by working on a copy

### Issues Resolved
#597

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass. (`$ ./build.sh`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
