### PR TITLE
added support to server maintenance mode for ServerHardware Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This release extends the planned support of the modules to OneView REST API vers
 #### Bug fixes & Enhancements
 - [#581] (https://github.com/HewlettPackard/oneview-ansible/issues/581) Updating single uplinkSet in LIG removes other uplinkSet.
 - [#582] (https://github.com/HewlettPackard/oneview-ansible/issues/582) Description field is empty after server profile creation.
-- [#599] (https://github.com/HewlettPackard/oneview-ansible/issues/599) Server maintenance mode.
+- [#599] (https://github.com/HewlettPackard/oneview-ansible/issues/599) Server maintenance mode..
 
 ### Modules supported in this release
 - image_streamer_artifact_bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This release extends the planned support of the modules to OneView REST API vers
 
 #### Bug fixes & Enhancements
 - [#581] (https://github.com/HewlettPackard/oneview-ansible/issues/581) Updating single uplinkSet in LIG removes other uplinkSet.
-- [#582] (https://github.com/HewlettPackard/oneview-ansible/issues/582) description field is empty after server profile creation
+- [#582] (https://github.com/HewlettPackard/oneview-ansible/issues/582) Description field is empty after server profile creation.
+- [#599] (https://github.com/HewlettPackard/oneview-ansible/issues/599) Server maintenance mode.
 
 ### Modules supported in this release
 - image_streamer_artifact_bundle

--- a/examples/oneview_server_hardware.yml
+++ b/examples/oneview_server_hardware.yml
@@ -11,7 +11,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License..
 ###
 
 ---

--- a/examples/oneview_server_hardware.yml
+++ b/examples/oneview_server_hardware.yml
@@ -138,6 +138,22 @@
             name: "{{ server_hardwares[0]['name'] }}"
       delegate_to: localhost
 
+    - name: Enable Server Maintenance Mode
+      oneview_server_hardware:
+        config: "{{ config }}"
+        state: enable_maintenance_mode
+        data:
+            name: "{{ server_hardwares[0]['name'] }}"
+      delegate_to: localhost
+                           
+    - name: Disable Server Maintenance Mode
+      oneview_server_hardware:
+        config: "{{ config }}"
+        state: disable_maintenance_mode
+        data:
+            name: "{{ server_hardwares[0]['name'] }}"
+      delegate_to: localhost
+
     # Commenting below tasks to ensure continuity for automation script
     # - name: Remove the server hardware by its IP
     #   oneview_server_hardware:

--- a/examples/oneview_server_hardware.yml
+++ b/examples/oneview_server_hardware.yml
@@ -11,7 +11,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License..
+# limitations under the License.
 ###
 
 ---

--- a/library/oneview_server_hardware.py
+++ b/library/oneview_server_hardware.py
@@ -43,11 +43,13 @@ options:
               C(ilo_state_reset) will reset the iLO state.
               C(uid_state_on) will set on the UID state, if necessary.
               C(uid_state_off) will set off the UID state, if necessary.
+              C(enable_maintenance_mode) will set true to the maintenance mode, if necessary.
+              C(disable_maintenance_mode) will set false to the maintenance mode, if necessary.
               C(environmental_configuration_set) will set the environmental configuration of the Server Hardware.
               C(multiple_servers_added) will add multiple rack-mount servers.
         choices: ['present', 'absent', 'power_state_set', 'refresh_state_set', 'ilo_firmware_version_updated',
-                  'ilo_state_reset','uid_state_on', 'uid_state_off', 'environmental_configuration_set',
-                  'multiple_servers_added']
+                  'ilo_state_reset','uid_state_on', 'uid_state_off', 'enable_maintenance_mode', 'disable_maintenance_mode',
+                  'environmental_configuration_set', 'multiple_servers_added']
         required: true
     data:
         description:
@@ -180,6 +182,28 @@ EXAMPLES = '''
     data:
         name : '0000A66102, bay 12'
   delegate_to: localhost
+
+- name: Enable Server Maintenance Mode
+  oneview_server_hardware:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 1200
+    state: enable_maintenance_mode
+    data:
+        name : '0000A66102, bay 12'
+  delegate_to: localhost
+
+- name: Disable Server Maintenance Mode
+  oneview_server_hardware:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 1200
+    state: disable_maintenance_mode
+    data:
+        name : '0000A66102, bay 12'
+  delegate_to: localhost
 '''
 
 RETURN = '''
@@ -202,6 +226,7 @@ class ServerHardwareModule(OneViewModule):
     MSG_ENV_CONFIG_UPDATED = 'Server Hardware calibrated max power updated successfully.'
     MSG_SERVER_HARDWARE_NOT_FOUND = 'The provided Server Hardware was not found.'
     MSG_UID_STATE_CHANGED = 'Server Hardware UID state changed successfully.'
+    MSG_MAINTENANCE_MODE_CHANGED = 'Server Hardware Maintenance Mode changed successfully.'
     MSG_ILO_STATE_RESET = 'Server Hardware iLO state changed successfully.'
     MSG_NOTHING_TO_DO = 'Nothing to do.'
     MSG_DELETED = 'Server Hardware deleted successfully.'
@@ -212,13 +237,17 @@ class ServerHardwareModule(OneViewModule):
     patch_success_message = dict(
         ilo_state_reset=MSG_ILO_STATE_RESET,
         uid_state_on=MSG_UID_STATE_CHANGED,
-        uid_state_off=MSG_UID_STATE_CHANGED
+        uid_state_off=MSG_UID_STATE_CHANGED,
+        enable_maintenance_mode=MSG_MAINTENANCE_MODE_CHANGED,
+        disable_maintenance_mode=MSG_MAINTENANCE_MODE_CHANGED
     )
 
     patch_params = dict(
         ilo_state_reset=dict(operation='replace', path='/mpState', value='Reset'),
         uid_state_on=dict(operation='replace', path='/uidState', value='On'),
-        uid_state_off=dict(operation='replace', path='/uidState', value='Off')
+        uid_state_off=dict(operation='replace', path='/uidState', value='Off'),
+        enable_maintenance_mode=dict(operation='replace', path='/maintenanceMode', value='true'),
+        disable_maintenance_mode=dict(operation='replace', path='/maintenanceMode', value='false')
     )
 
     argument_spec = dict(
@@ -233,6 +262,8 @@ class ServerHardwareModule(OneViewModule):
                 'ilo_state_reset',
                 'uid_state_on',
                 'uid_state_off',
+                'enable_maintenance_mode',
+                'disable_maintenance_mode',
                 'environmental_configuration_set',
                 'multiple_servers_added'
             ]

--- a/test/test_oneview_server_hardware.py
+++ b/test/test_oneview_server_hardware.py
@@ -113,6 +113,19 @@ YAML_SERVER_HARDWARE_UID_STATE_OFF = """
         data:
             name : "172.18.6.15"
 """
+YAML_SERVER_HARDWARE_ENABLE_MAINTENANCE_MODE = """
+        config: config
+        state: enable_maintenance_mode
+        data:
+            name : "172.18.6.15"
+"""
+
+YAML_SERVER_HARDWARE_DISABLE_MAINTENANCE_MODE = """
+        config: config
+        state: disable_maintenance_mode
+        data:
+            name : "172.18.6.15"
+"""
 
 SERVER_HARDWARE_HOSTNAME = "172.18.6.15"
 
@@ -376,6 +389,74 @@ class TestServerHardwareModule(OneViewBaseTest):
         self.resource.data = server_hardware
 
         self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_UID_STATE_OFF)
+
+        ServerHardwareModule().run()
+
+        self.resource.patch.assert_not_called()
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=ServerHardwareModule.MSG_NOTHING_TO_DO,
+            ansible_facts=dict(server_hardware=server_hardware)
+        )
+
+    def test_should_enable_maintenance_mode(self):
+        server_hardware_uri = "resourceuri"
+        self.resource.data = {"uri": server_hardware_uri, "maintenanceMode": "false"}
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ENABLE_MAINTENANCE_MODE)
+
+        ServerHardwareModule().run()
+
+        patch_params = ServerHardwareModule.patch_params['enable_maintenance_mode']
+        self.resource.patch.assert_called_once_with(**patch_params)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=ServerHardwareModule.MSG_MAINTENANCE_MODE_CHANGED,
+            ansible_facts=dict(server_hardware=self.resource.data)
+        )
+
+    def test_should_not_set_when_the_maintenance_mode_is_already_true(self):
+        server_hardware_uri = "resourceuri"
+        server_hardware = {"uri": server_hardware_uri, "maintenanceMode": "true"}
+
+        self.resource.data = server_hardware
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_ENABLE_MAINTENANCE_MODE)
+
+        ServerHardwareModule().run()
+
+        self.resource.patch.assert_not_called()
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=ServerHardwareModule.MSG_NOTHING_TO_DO,
+            ansible_facts=dict(server_hardware=server_hardware)
+        )
+
+    def test_should_disable_maintenance_mode(self):
+        server_hardware_uri = "resourceuri"
+
+        self.resource.data = {"uri": server_hardware_uri, "maintenanceMode": "true"}
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_DISABLE_MAINTENANCE_MODE)
+
+        ServerHardwareModule().run()
+        patch_params = ServerHardwareModule.patch_params['disable_maintenance_mode']
+        self.resource.patch.assert_called_once_with(**patch_params)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=ServerHardwareModule.MSG_MAINTENANCE_MODE_CHANGED,
+            ansible_facts=dict(server_hardware=self.resource.data)
+        )
+
+    def test_should_not_set_when_the_maintenance_mode_is_already_false(self):
+        server_hardware_uri = "resourceuri"
+        server_hardware = {"uri": server_hardware_uri, "maintenanceMode": "false"}
+
+        self.resource.data = server_hardware
+
+        self.mock_ansible_module.params = yaml.load(YAML_SERVER_HARDWARE_DISABLE_MAINTENANCE_MODE)
 
         ServerHardwareModule().run()
 


### PR DESCRIPTION
### Description
Added support to server maintenance mode feature of ServerHardware Resource

### Issues Resolved
#599 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass. (`$ ./build.sh`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
